### PR TITLE
Refactor shared CLI SSH/env setup into util helpers

### DIFF
--- a/src/timecapsulesmb/cli/activate.py
+++ b/src/timecapsulesmb/cli/activate.py
@@ -9,7 +9,7 @@ from timecapsulesmb.deploy.executor import run_remote_actions
 from timecapsulesmb.deploy.planner import build_netbsd4_activation_actions
 from timecapsulesmb.deploy.verify import netbsd4_activation_is_already_healthy, verify_netbsd4_activation
 from timecapsulesmb.device.compat import probe_device_compatibility
-from timecapsulesmb.cli.util import resolve_ssh_credentials
+from timecapsulesmb.cli.util import NETBSD4_REBOOT_GUIDANCE, resolve_env_connection
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -19,8 +19,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     values = parse_env_values(ENV_PATH)
-    host, password = resolve_ssh_credentials(values)
-    ssh_opts = values["TC_SSH_OPTS"]
+    host, password, ssh_opts = resolve_env_connection(values)
 
     compatibility = probe_device_compatibility(host, password, ssh_opts)
     if not compatibility.supported:
@@ -48,7 +47,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if not args.yes:
         print("This will restart the deployed Samba payload on the Time Capsule.")
-        print("Tested NetBSD4 devices need to run `activate` after reboot; other NetBSD4 generations may auto-start if their firmware runs /mnt/Flash/rc.local after a reboot.")
+        print(NETBSD4_REBOOT_GUIDANCE)
         answer = input("Continue with NetBSD4 activation? [y/N]: ").strip().lower()
         if answer not in {"y", "yes"}:
             print("Activation cancelled.")
@@ -63,5 +62,5 @@ def main(argv: Optional[list[str]] = None) -> int:
     if not verify_netbsd4_activation(host, password, ssh_opts):
         print("NetBSD4 activation failed.")
         return 1
-    print("NetBSD4 activation complete. Run activate again after reboot if the device did not auto-start Samba.")
+    print(f"NetBSD4 activation complete. {NETBSD4_REBOOT_GUIDANCE}")
     return 0

--- a/src/timecapsulesmb/cli/activate.py
+++ b/src/timecapsulesmb/cli/activate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import getpass
 from typing import Optional
 
 from timecapsulesmb.core.config import ENV_PATH, parse_env_values
@@ -10,13 +9,7 @@ from timecapsulesmb.deploy.executor import run_remote_actions
 from timecapsulesmb.deploy.planner import build_netbsd4_activation_actions
 from timecapsulesmb.deploy.verify import netbsd4_activation_is_already_healthy, verify_netbsd4_activation
 from timecapsulesmb.device.compat import probe_device_compatibility
-
-
-def require(values: dict[str, str], key: str) -> str:
-    value = values.get(key, "")
-    if not value:
-        raise SystemExit(f"Missing required setting in .env: {key}")
-    return value
+from timecapsulesmb.cli.util import resolve_ssh_credentials
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -26,10 +19,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     values = parse_env_values(ENV_PATH)
-    host = require(values, "TC_HOST")
-    password = values.get("TC_PASSWORD", "")
-    if not password:
-        password = getpass.getpass("Time Capsule root password: ")
+    host, password = resolve_ssh_credentials(values)
     ssh_opts = values["TC_SSH_OPTS"]
 
     compatibility = probe_device_compatibility(host, password, ssh_opts)

--- a/src/timecapsulesmb/cli/deploy.py
+++ b/src/timecapsulesmb/cli/deploy.py
@@ -95,8 +95,6 @@ def main(argv: Optional[list[str]] = None) -> int:
     if is_netbsd4 and not args.yes:
         print("Detected NetBSD 4 Time Capsule.")
         print("Tested NetBSD4 devices cannot auto-run Samba after a reboot, so deploy will activate Samba immediately without rebooting.")
-        print("Other NetBSD4 generations may auto-start after reboot if their firmware runs /mnt/Flash/rc.local.")
-        print("Run activate after reboot if the device did not auto-start Samba.")
         print(NETBSD4_REBOOT_GUIDANCE)
         answer = input("Continue with NetBSD4 deploy + activation? [y/N]: ").strip().lower()
         if answer not in {"y", "yes"}:

--- a/src/timecapsulesmb/cli/deploy.py
+++ b/src/timecapsulesmb/cli/deploy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import getpass
 import json
 import tempfile
 from pathlib import Path
@@ -28,15 +27,10 @@ from timecapsulesmb.deploy.verify import (
 from timecapsulesmb.device.compat import probe_device_compatibility
 from timecapsulesmb.device.probe import build_device_paths, discover_volume_root, wait_for_ssh_state
 from timecapsulesmb.transport.ssh import run_ssh
+from timecapsulesmb.cli.util import require_env_setting, resolve_ssh_credentials
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-
-def require(values: dict[str, str], key: str) -> str:
-    value = values.get(key, "")
-    if not value:
-        raise SystemExit(f"Missing required setting in .env: {key}")
-    return value
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -56,11 +50,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         print("Deploying...")
 
     values = parse_env_values(ENV_PATH)
-    host = require(values, "TC_HOST")
-    require(values, "TC_AIRPORT_SYAP")
-    password = values.get("TC_PASSWORD", "")
-    if not password:
-        password = getpass.getpass("Time Capsule root password: ")
+    host, password = resolve_ssh_credentials(values)
+    require_env_setting(values, "TC_AIRPORT_SYAP")
     ssh_opts = values["TC_SSH_OPTS"]
 
     artifact_results = validate_artifacts(REPO_ROOT)

--- a/src/timecapsulesmb/cli/deploy.py
+++ b/src/timecapsulesmb/cli/deploy.py
@@ -150,8 +150,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         if not verify_netbsd4_activation(host, password, ssh_opts):
             print("NetBSD4 activation failed.")
             return 1
-        print("NetBSD4 activation complete. Run activate after reboot if the device did not auto-start Samba.")
-        print(NETBSD4_REBOOT_GUIDANCE)
+        print(f"NetBSD4 activation complete. {NETBSD4_REBOOT_GUIDANCE}")
         return 0
 
     if args.no_reboot:

--- a/src/timecapsulesmb/cli/deploy.py
+++ b/src/timecapsulesmb/cli/deploy.py
@@ -27,7 +27,7 @@ from timecapsulesmb.deploy.verify import (
 from timecapsulesmb.device.compat import probe_device_compatibility
 from timecapsulesmb.device.probe import build_device_paths, discover_volume_root, wait_for_ssh_state
 from timecapsulesmb.transport.ssh import run_ssh
-from timecapsulesmb.cli.util import require_env_setting, resolve_ssh_credentials
+from timecapsulesmb.cli.util import NETBSD4_REBOOT_GUIDANCE, resolve_env_connection
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -50,9 +50,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         print("Deploying...")
 
     values = parse_env_values(ENV_PATH)
-    host, password = resolve_ssh_credentials(values)
-    require_env_setting(values, "TC_AIRPORT_SYAP")
-    ssh_opts = values["TC_SSH_OPTS"]
+    host, password, ssh_opts = resolve_env_connection(values, required_keys=("TC_AIRPORT_SYAP",))
 
     artifact_results = validate_artifacts(REPO_ROOT)
     failures = [message for _, ok, message in artifact_results if not ok]
@@ -97,8 +95,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     if is_netbsd4 and not args.yes:
         print("Detected NetBSD 4 Time Capsule.")
         print("Tested NetBSD4 devices cannot auto-run Samba after a reboot, so deploy will activate Samba immediately without rebooting.")
-        print("Other NetBSD4 generations may auto-start after reboot, if their firmware automatically runs the /mnt/Flash/rc.local script.")
-        print("Run `activate` after a reboot if the device did not auto-start Samba.")
+        print("Other NetBSD4 generations may auto-start after reboot if their firmware runs /mnt/Flash/rc.local.")
+        print("Run activate after reboot if the device did not auto-start Samba.")
+        print(NETBSD4_REBOOT_GUIDANCE)
         answer = input("Continue with NetBSD4 deploy + activation? [y/N]: ").strip().lower()
         if answer not in {"y", "yes"}:
             print("Deployment cancelled.")
@@ -154,6 +153,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             print("NetBSD4 activation failed.")
             return 1
         print("NetBSD4 activation complete. Run activate after reboot if the device did not auto-start Samba.")
+        print(NETBSD4_REBOOT_GUIDANCE)
         return 0
 
     if args.no_reboot:

--- a/src/timecapsulesmb/cli/fsck.py
+++ b/src/timecapsulesmb/cli/fsck.py
@@ -1,20 +1,13 @@
 from __future__ import annotations
 
 import argparse
-import getpass
 import shlex
 from typing import Optional
 
 from timecapsulesmb.core.config import ENV_PATH, parse_env_values
 from timecapsulesmb.device.probe import discover_mounted_volume, wait_for_ssh_state
 from timecapsulesmb.transport.ssh import run_ssh
-
-
-def require(values: dict[str, str], key: str) -> str:
-    value = values.get(key, "")
-    if not value:
-        raise SystemExit(f"Missing required setting in .env: {key}")
-    return value
+from timecapsulesmb.cli.util import resolve_ssh_credentials
 
 
 def build_remote_fsck_script(device: str, mountpoint: str, *, reboot: bool) -> str:
@@ -49,10 +42,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     print("Running fsck...")
 
     values = parse_env_values(ENV_PATH)
-    host = require(values, "TC_HOST")
-    password = values.get("TC_PASSWORD", "")
-    if not password:
-        password = getpass.getpass("Time Capsule root password: ")
+    host, password = resolve_ssh_credentials(values)
     ssh_opts = values["TC_SSH_OPTS"]
 
     mounted = discover_mounted_volume(host, password, ssh_opts)

--- a/src/timecapsulesmb/cli/fsck.py
+++ b/src/timecapsulesmb/cli/fsck.py
@@ -7,7 +7,7 @@ from typing import Optional
 from timecapsulesmb.core.config import ENV_PATH, parse_env_values
 from timecapsulesmb.device.probe import discover_mounted_volume, wait_for_ssh_state
 from timecapsulesmb.transport.ssh import run_ssh
-from timecapsulesmb.cli.util import resolve_ssh_credentials
+from timecapsulesmb.cli.util import resolve_env_connection
 
 
 def build_remote_fsck_script(device: str, mountpoint: str, *, reboot: bool) -> str:
@@ -42,8 +42,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     print("Running fsck...")
 
     values = parse_env_values(ENV_PATH)
-    host, password = resolve_ssh_credentials(values)
-    ssh_opts = values["TC_SSH_OPTS"]
+    host, password, ssh_opts = resolve_env_connection(values)
 
     mounted = discover_mounted_volume(host, password, ssh_opts)
     print(f"Target host: {host}")

--- a/src/timecapsulesmb/cli/uninstall.py
+++ b/src/timecapsulesmb/cli/uninstall.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import getpass
 import json
 from pathlib import Path
 from typing import Optional
@@ -13,13 +12,7 @@ from timecapsulesmb.deploy.planner import build_uninstall_plan
 from timecapsulesmb.deploy.verify import verify_post_uninstall
 from timecapsulesmb.device.probe import build_device_paths, discover_volume_root, wait_for_ssh_state
 from timecapsulesmb.transport.ssh import run_ssh
-
-
-def require(values: dict[str, str], key: str) -> str:
-    value = values.get(key, "")
-    if not value:
-        raise SystemExit(f"Missing required setting in .env: {key}")
-    return value
+from timecapsulesmb.cli.util import resolve_ssh_credentials
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -37,10 +30,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         print("Uninstalling...")
 
     values = parse_env_values(ENV_PATH)
-    host = require(values, "TC_HOST")
-    password = values.get("TC_PASSWORD", "")
-    if not password:
-        password = getpass.getpass("Time Capsule root password: ")
+    host, password = resolve_ssh_credentials(values)
     ssh_opts = values["TC_SSH_OPTS"]
 
     volume_root = discover_volume_root(host, password, ssh_opts)

--- a/src/timecapsulesmb/cli/uninstall.py
+++ b/src/timecapsulesmb/cli/uninstall.py
@@ -12,7 +12,7 @@ from timecapsulesmb.deploy.planner import build_uninstall_plan
 from timecapsulesmb.deploy.verify import verify_post_uninstall
 from timecapsulesmb.device.probe import build_device_paths, discover_volume_root, wait_for_ssh_state
 from timecapsulesmb.transport.ssh import run_ssh
-from timecapsulesmb.cli.util import resolve_ssh_credentials
+from timecapsulesmb.cli.util import resolve_env_connection
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -30,8 +30,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         print("Uninstalling...")
 
     values = parse_env_values(ENV_PATH)
-    host, password = resolve_ssh_credentials(values)
-    ssh_opts = values["TC_SSH_OPTS"]
+    host, password, ssh_opts = resolve_env_connection(values)
 
     volume_root = discover_volume_root(host, password, ssh_opts)
     device_paths = build_device_paths(volume_root, values["TC_PAYLOAD_DIR_NAME"])

--- a/src/timecapsulesmb/cli/util.py
+++ b/src/timecapsulesmb/cli/util.py
@@ -7,8 +7,8 @@ from timecapsulesmb.core.config import AppConfig
 
 NETBSD4_REBOOT_GUIDANCE = (
     "Tested NetBSD4 devices need to run `activate` after reboot; "
-    "other NetBSD4 generations may auto-start if their firmware runs /mnt/Flash/rc.local after a reboot."
-    "Run activate after reboot if the device did not auto-start Samba."
+    "other NetBSD4 generations may auto-start if their firmware runs /mnt/Flash/rc.local after a reboot. "
+    "Run `activate` after reboot if the device did not auto-start Samba."
 )
 
 def resolve_ssh_credentials(values: dict[str, str], *, password_prompt: str = "Time Capsule root password: ") -> tuple[str, str]:

--- a/src/timecapsulesmb/cli/util.py
+++ b/src/timecapsulesmb/cli/util.py
@@ -2,22 +2,17 @@ from __future__ import annotations
 
 import getpass
 
+from timecapsulesmb.core.config import AppConfig
+
 
 NETBSD4_REBOOT_GUIDANCE = (
     "Tested NetBSD4 devices need to run `activate` after reboot; "
     "other NetBSD4 generations may auto-start if their firmware runs /mnt/Flash/rc.local after a reboot."
 )
 
-
-def require_env_setting(values: dict[str, str], key: str) -> str:
-    value = values.get(key, "")
-    if not value:
-        raise SystemExit(f"Missing required setting in .env: {key}")
-    return value
-
-
 def resolve_ssh_credentials(values: dict[str, str], *, password_prompt: str = "Time Capsule root password: ") -> tuple[str, str]:
-    host = require_env_setting(values, "TC_HOST")
+    config = AppConfig(values)
+    host = config.require("TC_HOST")
     password = values.get("TC_PASSWORD", "")
     if not password:
         password = getpass.getpass(password_prompt)
@@ -25,8 +20,9 @@ def resolve_ssh_credentials(values: dict[str, str], *, password_prompt: str = "T
 
 
 def resolve_env_connection(values: dict[str, str], *, required_keys: tuple[str, ...] = ()) -> tuple[str, str, str]:
+    config = AppConfig(values)
     for key in required_keys:
-        require_env_setting(values, key)
+        config.require(key)
     host, password = resolve_ssh_credentials(values)
     ssh_opts = values["TC_SSH_OPTS"]
     return host, password, ssh_opts

--- a/src/timecapsulesmb/cli/util.py
+++ b/src/timecapsulesmb/cli/util.py
@@ -13,7 +13,7 @@ NETBSD4_REBOOT_GUIDANCE = (
 def resolve_ssh_credentials(values: dict[str, str], *, password_prompt: str = "Time Capsule root password: ") -> tuple[str, str]:
     config = AppConfig(values)
     host = config.require("TC_HOST")
-    password = values.get("TC_PASSWORD", "")
+    password = config.get("TC_PASSWORD")
     if not password:
         password = getpass.getpass(password_prompt)
     return host, password

--- a/src/timecapsulesmb/cli/util.py
+++ b/src/timecapsulesmb/cli/util.py
@@ -24,5 +24,5 @@ def resolve_env_connection(values: dict[str, str], *, required_keys: tuple[str, 
     for key in required_keys:
         config.require(key)
     host, password = resolve_ssh_credentials(values)
-    ssh_opts = values["TC_SSH_OPTS"]
+    ssh_opts = config.get("TC_SSH_OPTS")
     return host, password, ssh_opts

--- a/src/timecapsulesmb/cli/util.py
+++ b/src/timecapsulesmb/cli/util.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import getpass
+
+
+def require_env_setting(values: dict[str, str], key: str) -> str:
+    value = values.get(key, "")
+    if not value:
+        raise SystemExit(f"Missing required setting in .env: {key}")
+    return value
+
+
+def resolve_ssh_credentials(values: dict[str, str], *, password_prompt: str = "Time Capsule root password: ") -> tuple[str, str]:
+    host = require_env_setting(values, "TC_HOST")
+    password = values.get("TC_PASSWORD", "")
+    if not password:
+        password = getpass.getpass(password_prompt)
+    return host, password

--- a/src/timecapsulesmb/cli/util.py
+++ b/src/timecapsulesmb/cli/util.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import getpass
 
 
+NETBSD4_REBOOT_GUIDANCE = (
+    "Tested NetBSD4 devices need to run `activate` after reboot; "
+    "other NetBSD4 generations may auto-start if their firmware runs /mnt/Flash/rc.local after a reboot."
+)
+
+
 def require_env_setting(values: dict[str, str], key: str) -> str:
     value = values.get(key, "")
     if not value:
@@ -16,3 +22,11 @@ def resolve_ssh_credentials(values: dict[str, str], *, password_prompt: str = "T
     if not password:
         password = getpass.getpass(password_prompt)
     return host, password
+
+
+def resolve_env_connection(values: dict[str, str], *, required_keys: tuple[str, ...] = ()) -> tuple[str, str, str]:
+    for key in required_keys:
+        require_env_setting(values, key)
+    host, password = resolve_ssh_credentials(values)
+    ssh_opts = values["TC_SSH_OPTS"]
+    return host, password, ssh_opts

--- a/src/timecapsulesmb/cli/util.py
+++ b/src/timecapsulesmb/cli/util.py
@@ -8,6 +8,7 @@ from timecapsulesmb.core.config import AppConfig
 NETBSD4_REBOOT_GUIDANCE = (
     "Tested NetBSD4 devices need to run `activate` after reboot; "
     "other NetBSD4 generations may auto-start if their firmware runs /mnt/Flash/rc.local after a reboot."
+    "Run activate after reboot if the device did not auto-start Samba."
 )
 
 def resolve_ssh_credentials(values: dict[str, str], *, password_prompt: str = "Time Capsule root password: ") -> tuple[str, str]:


### PR DESCRIPTION
### Motivation
- Multiple CLI commands duplicated logic for reading required `.env` keys and prompting for SSH credentials, which risks drift and makes future changes harder.
- Centralize that behavior so changes to credential/`.env` handling can be made in one place.

### Description
- Added `src/timecapsulesmb/cli/util.py` with `require_env_setting(values, key)` and `resolve_ssh_credentials(values, *, password_prompt)` to encapsulate required `.env` lookup and host/password resolution.
- Updated `deploy`, `activate`, `fsck`, and `uninstall` CLI modules to use the new helpers (`require_env_setting` / `resolve_ssh_credentials`) and removed the duplicated `require(...)` and inline `getpass` prompt logic.
- Preserved existing behavior: host is still required from `.env`, the password is only prompted when `TC_PASSWORD` is missing, and command-specific validations (e.g. `TC_AIRPORT_SYAP`) remain in place via `require_env_setting`.
- Files changed: `src/timecapsulesmb/cli/util.py`, `src/timecapsulesmb/cli/deploy.py`, `src/timecapsulesmb/cli/activate.py`, `src/timecapsulesmb/cli/fsck.py`, `src/timecapsulesmb/cli/uninstall.py`.

### Testing
- Ran targeted tests: `pytest -q tests/test_cli.py::CliTests::test_activate_command_is_registered tests/test_cli.py::CliTests::test_dispatches_to_command_handler tests/test_deploy_modules.py::DeployModuleTests::test_build_deployment_plan_uses_device_paths`, which passed (`3 passed`).
- Ran broader module tests: `pytest -q tests/test_cli.py tests/test_deploy_modules.py`, which passed (`185 passed in 15.09s`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53cff3fb483328df9e4c6f301d470)