### PR TITLE
Add found, expected params to warning

### DIFF
--- a/src/timecapsulesmb/core/config.py
+++ b/src/timecapsulesmb/core/config.py
@@ -377,7 +377,8 @@ def validate_mdns_device_model_matches_syap(syap: str, device_model: str) -> Opt
     if expected_model is None:
         return None
     if device_model != expected_model:
-        return "TC_MDNS_DEVICE_MODEL must match the configured syAP."
+        return ('TC_MDNS_DEVICE_MODEL "%s" must match the configured '
+                'syAP expected value "%s".' % (device_model, expected_model))
     return None
 
 

--- a/src/timecapsulesmb/core/config.py
+++ b/src/timecapsulesmb/core/config.py
@@ -377,8 +377,8 @@ def validate_mdns_device_model_matches_syap(syap: str, device_model: str) -> Opt
     if expected_model is None:
         return None
     if device_model != expected_model:
-        return ('TC_MDNS_DEVICE_MODEL "%s" must match the configured '
-                'syAP expected value "%s".' % (device_model, expected_model))
+        return (f'TC_MDNS_DEVICE_MODEL "{device_model}" must match the '
+                f'configured syAP expected value "{expected_model}".')
     return None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2017,7 +2017,8 @@ class CliTests(unittest.TestCase):
         self.assertEqual(
             str(ctx.exception),
             "TC_MDNS_DEVICE_MODEL is invalid. Run the `configure` command again.\n"
-            "TC_MDNS_DEVICE_MODEL must match the configured syAP.",
+            'TC_MDNS_DEVICE_MODEL "TimeCapsule" must match the configured '
+            'syAP expected value "TimeCapsule8,119".'
         )
 
     def test_deploy_rejects_missing_remote_interface(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,11 +111,13 @@ class ConfigTests(unittest.TestCase):
         self.assertIsNone(validate_mdns_device_model_matches_syap("119", "TimeCapsule8,119"))
         self.assertEqual(
             validate_mdns_device_model_matches_syap("119", "TimeCapsule"),
-            "TC_MDNS_DEVICE_MODEL must match the configured syAP.",
+            'TC_MDNS_DEVICE_MODEL "TimeCapsule" must match the configured '
+            'syAP expected value "TimeCapsule8,119".'
         )
         self.assertEqual(
             validate_mdns_device_model_matches_syap("119", "TimeCapsule6,113"),
-            "TC_MDNS_DEVICE_MODEL must match the configured syAP.",
+            'TC_MDNS_DEVICE_MODEL "TimeCapsule6,113" must match the configured '
+            'syAP expected value "TimeCapsule8,119".'
         )
         self.assertIsNone(validate_mdns_device_model_matches_syap("", "TimeCapsule"))
 
@@ -377,7 +379,9 @@ class ConfigTests(unittest.TestCase):
         values["TC_MDNS_DEVICE_MODEL"] = "TimeCapsule"
         errors = validate_config_values(values, profile="deploy")
         self.assertEqual(errors[0].key, "TC_MDNS_DEVICE_MODEL")
-        self.assertEqual(errors[0].message, "TC_MDNS_DEVICE_MODEL must match the configured syAP.")
+        self.assertEqual(errors[0].message,
+                         'TC_MDNS_DEVICE_MODEL "TimeCapsule" must match the '
+                         'configured syAP expected value "TimeCapsule8,119".')
 
     def test_app_config_require_raises_for_missing_value(self) -> None:
         config = AppConfig({"TC_HOST": ""})


### PR DESCRIPTION
Previously, we got the generic error:

```
"TC_MDNS_DEVICE_MODEL must match the configured syAP."
```

This PR makes the error more helpful by noting the found and expected result.

Fix tests accordingly.

In testing this PR, and the install with my Gen 3 TC, I run `tcapsule configure`, accept the defaults, and then:

```
$ tcapsule deploy
Deploying...
TC_MDNS_DEVICE_MODEL is invalid. Run the `configure` command again.
TC_MDNS_DEVICE_MODEL "TimeCapsule" must match the configured syAP expected value "TimeCapsule6,113".
```