### PR TITLE
Add TCAPSULE_NO_VERSION_CHECK to skip the remote version check

### DIFF
--- a/DETAIL.md
+++ b/DETAIL.md
@@ -639,6 +639,7 @@ The top-level command dispatcher supports:
 
 Shared command behavior:
 - all commands except `api` perform the client version check before running, unless the invocation is only asking for `-h` or `--help`
+- setting `TCAPSULE_NO_VERSION_CHECK=1` skips the remote version check entirely (no outbound request); the check already fails open when the endpoint is unreachable
 - commands that read the device config accept `--config PATH`, which overrides `TCAPSULE_CONFIG` and the repo-local `.env`
 - commands that can prompt usually accept `--no-input`; in that mode they fail instead of asking for missing input or confirmation
 - commands that can make destructive or rebooting changes use `--yes` to skip confirmation in interactive and non-interactive runs

--- a/src/timecapsulesmb/services/version_check.py
+++ b/src/timecapsulesmb/services/version_check.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 import urllib.request
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
@@ -12,6 +14,8 @@ from timecapsulesmb.core.release import CLI_VERSION, CLI_VERSION_CODE
 
 
 VERSION_CHECK_URL = "https://raw.githubusercontent.com/jamesyc/TimeCapsuleSMB/main/version.json"
+NO_VERSION_CHECK_ENV = "TCAPSULE_NO_VERSION_CHECK"
+_TRUTHY = frozenset({"true", "1", "yes", "on"})
 DEFAULT_DOWNLOAD_URL = "https://github.com/jamesyc/TimeCapsuleSMB/releases/latest"
 DEFAULT_UNSUPPORTED_MESSAGE = "This version is no longer supported. Please update before continuing."
 VERSION_CHECK_TIMEOUT_SECONDS = 3.0
@@ -150,6 +154,11 @@ def default_version_check_cache_path() -> Path:
     return resolve_app_paths().version_check_cache_path
 
 
+def version_check_disabled(env: Mapping[str, str] | None = None) -> bool:
+    environ = os.environ if env is None else env
+    return environ.get(NO_VERSION_CHECK_ENV, "").strip().lower() in _TRUTHY
+
+
 def check_client_version(
     *,
     local_version_code: int = CLI_VERSION_CODE,
@@ -158,7 +167,10 @@ def check_client_version(
     cache_path: Path | None = None,
     now: float | None = None,
     opener: UrlOpen = urllib.request.urlopen,
+    env: Mapping[str, str] | None = None,
 ) -> VersionCheckResult:
+    if version_check_disabled(env):
+        return VersionCheckResult(should_block=False, checked_url=url, local_version_code=local_version_code, source="disabled")
     try:
         return _check_client_version(
             local_version_code=local_version_code,

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -312,6 +312,28 @@ class VersionCheckTests(unittest.TestCase):
         self.assertIn("Update required.", text)
         self.assertIn(f"Client version is out of date, download the latest version from: {DEFAULT_DOWNLOAD_URL}", text)
 
+    def test_env_opt_out_skips_check_without_network(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "version-cache.json"
+            calls: list[tuple[object, float]] = []
+
+            def opener(_request, _timeout):
+                calls.append((_request, _timeout))
+                raise AssertionError("network must not be used when the check is disabled")
+
+            result = check_client_version(
+                local_version_code=20004,
+                cache_path=cache_path,
+                now=1000.0,
+                opener=opener,
+                env={"TCAPSULE_NO_VERSION_CHECK": "1"},
+            )
+
+            self.assertFalse(result.should_block)
+            self.assertEqual(result.source, "disabled")
+            self.assertEqual(calls, [])
+            self.assertFalse(cache_path.exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Adds a single opt-out env var, `TCAPSULE_NO_VERSION_CHECK=1`, that skips the remote version check so a run makes no outbound request.

## Why

Per your feedback: the existing strong update-enforcement behavior is kept exactly as-is (it's good for pressuring users off vulnerable Samba builds), and it already fails open when the endpoint is unreachable. This just gives users who want a fully offline run an explicit switch instead of having to physically pull the network.

## Changes

- `version_check_disabled(env)` + an `env` param on `check_client_version`; when the var is set, it returns a non-blocking result with `source="disabled"` and makes no network call or cache write.
- No change to the block-on-outdated behavior, the URL, or anything else.
- Test + one DETAIL.md line.

I dropped the advisory/local-floor rework and the redirect changes from the original PR as you requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)