### PR TITLE
Polish repo tooling docs: idempotent make install, README stage list, AGENTS.md, .gitignore logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,11 @@ xcuserdata/
 .deps/
 .airpyrt-venv/
 
-# Installer logs
+# Installer and device logs (never commit device logs — see AGENTS.md)
 pip-log.txt
 pip-delete-this-directory.txt
+*.log
+*.log.*
 
 # Test / coverage
 .pytest_cache/
@@ -57,3 +59,6 @@ coverage.xml
 .env.backup*
 .bootstrap
 .version-check-cache.json
+
+# Generated knowledge graph (regenerate with the /graphify skill)
+graphify-out/

--- a/AGENTS-REWRITE.md
+++ b/AGENTS-REWRITE.md
@@ -1,0 +1,216 @@
+# Meta-Prompt: Rewrite an Application into a Simpler, Clean-Architecture Version
+
+> **How to use (human operator):**
+> 1. Fill in every `{{PLACEHOLDER}}` in *Project Parameters* below. Placeholders appear **only** in that section.
+> 2. Save this file as `AGENTS.md` at the repo root. For Claude Code, also create `CLAUDE.md` containing the single line `@AGENTS.md`. For Gemini CLI, create `GEMINI.md` containing `Read AGENTS.md and follow it.` Keep this file under 32 KB (Codex truncates beyond that).
+> 3. Recommended extras (the prompt degrades gracefully without them): the Superpowers plugin (`/plugin install superpowers@claude-plugins-official` on Claude Code) and the Context7, Playwright, and Serena MCP servers.
+> 4. **Running the loop.** Interactive: start each session with *"Read AGENTS.md and begin."* Unattended (any harness with a CLI):
+>    `while :; do claude -p "Read AGENTS.md and begin" || break; done` (or `codex exec ...` / `opencode run ...`).
+>    The agent exits after one work unit. If the first line of `PROGRESS.md` starts with `BLOCKED:`, the agent prints the pending question and exits immediately — answer it, delete the `BLOCKED:` line, and the loop resumes.
+> 5. **Approvals are yours alone.** You grant a phase gate by adding a line to `DECISIONS.md`: `APPROVED: <phase-0|phase-1|change-list> @ <git SHA> <date>` (or by telling the agent verbatim to write it). The agent may never write an `APPROVED:` line on its own initiative.
+
+---
+
+## Project Parameters (operator fills in — placeholders live only here)
+
+- **App to rewrite:** `src/timecapsulesmb/` (Python CLI package `timecapsulesmb` that deploys a modern Samba 4 server onto Apple AirPort Time Capsules over SSH) **and** `macos/TimeCapsuleSMB/` (SwiftUI macOS GUI frontend that spawns the Python `tcapsule api` backend as a JSON-lines subprocess). Both are rewritten.
+- **Legacy build/run/test commands:** Bootstrap: `./tcapsule bootstrap` (builds `.venv` + `tcapsule` console script; the root `tcapsule` only execs the venv binary). Run: `.venv/bin/tcapsule <discover|configure|deploy|activate|flash-patch|doctor|uninstall|api> ...`. Full verification: `make test-parallel` (C compile checks via `make test-c` + pytest-xdist `--dist loadfile`). Focused: `.venv/bin/pytest tests/test_foo.py`. Lint: `make lint` (ruff on `src tests macos/TimeCapsuleSMB/tools tcapsule`; py39 target, line-length 100, rules E9/F63/F7/F82). Swift tests (macOS only): `swift test --package-path macos/TimeCapsuleSMB`. Env vars: `.env` in repo root (gitignored) with `TC_HOST`/`TC_PASSWORD`; `TCAPSULE_HELPER` overrides the helper path; telemetry on by default, `tests/conftest.py` blocks unmocked telemetry posts.
+- **Target stack:** same language/framework, latest stable versions — Python current stable (new code does NOT need the legacy py3.9 floor; CI matrix for new code = current Python only unless a CHANGE entry says otherwise) and current SwiftUI/Xcode.
+- **New code location:** `/Users/felipe.dos.santos/code/apple-time-capsule-utils` — a **new, separate git repo with no legacy code** (operator's explicit choice). All "new code" checks are scoped to that repo. The legacy repo `TimeCapsuleSMB` stays untouched as the behavior oracle. In-place rewrite clause does not apply.
+- **Out of scope:** no new features, no UI redesign, no database migration (none exists). No changes to the on-device NetBSD runtime (`assets/boot/samba4/*` shell scripts) or the prebuilt `bin/` NetBSD binaries — these are deployment payloads copied verbatim as data, not rewritten. No firmware/VM work under `build/`.
+- **Iteration budgets:** defaults — Phase 0 ≤ 10 sessions; Phase 1 ≤ 5; Phase 2 ≤ 5 sessions *per slice*; Phase 3 ≤ 5. Counted in `PROGRESS.md`.
+- **Essential functionality** is defined by the approved `FEATURES.json` — never by anyone's memory.
+
+---
+
+## 1. NORTH STAR (immutable — never edit this section)
+
+Rewrite the application defined in *Project Parameters* into a **simpler, functionally equivalent** version with: decoupled layers that obey the Dependency Rule; reusable, single-responsibility components; and standardized entities, constants, logging, and error handling as defined in Section 7. Every behavior tagged KEEP in `FEATURES.json` must work identically in the new code; every CHANGE behaves as approved; every DROP is verifiably absent. Simpler means fewer concepts, less duplication, smaller units, explicit boundaries — **never** fewer working features.
+
+At the start of every session, restate this goal in one sentence in `PROGRESS.md` before doing any work.
+
+## 2. Definition of Done (mechanical)
+
+Complete only when **all** of the following hold:
+
+1. Every **KEEP** entry in `FEATURES.json` has `"passes": true`, evidenced by green characterization tests; every **CHANGE** entry passes tests encoding its approved behavior; every **DROP** entry has `"passes": true` with evidence that it is absent from the new code (search command + zero results, recorded in `PROGRESS.md`).
+2. The full test suite — including all characterization tests captured from the legacy app — is green.
+3. `grep -rn "TRANSITIONAL:" <new-repo>/` returns zero results, and the dependency-check rule (Section 7.1), configured to also forbid new-code imports of legacy modules, passes.
+4. The final review (Phase 3 step 3) reports no Critical or Important findings. *Severity: Critical = breaks parity or the DoD; Important = violates Section 7; Minor = style.*
+5. The standards self-audit (Section 7) passes for every new-code module.
+
+Only the `passes` field of `FEATURES.json` may ever change after approval. Removing or editing entries, or weakening tests, to reach Done is a violation — it hides missing or broken functionality.
+
+## 3. Session Start Protocol (every session, and after any context compaction)
+
+0. Read the first line of `PROGRESS.md`. If it starts with `BLOCKED:`, print the pending question and **exit immediately**. Do nothing else.
+1. `pwd`; confirm repo root. Read Section 1, then (each **if it exists**) `PLAN.md`, the last 3 entries of `PROGRESS.md`, `DECISIONS.md`, and `git log --oneline -15`.
+2. Run Capability Discovery (Section 4).
+3. **Phase routing** (artifacts + `APPROVED:` lines in `DECISIONS.md` decide — never your recollection):
+   - No `FEATURES.json`, or no `APPROVED: phase-0` line → you are in **Phase 0**.
+   - `APPROVED: phase-0` present but no `APPROVED: phase-1` → **Phase 1**.
+   - `APPROVED: phase-1` present and DoD items not all met → **Phase 2** (or **Phase 3** if every KEEP/CHANGE entry already passes).
+4. If `PLAN.md` exists: run the build and test suite (commands at its top). **If anything is broken, fixing it is your only task this session**; if the same breakage survives 3 recorded attempts, escalate (Section 9). Before Phase 1, use the legacy commands from *Project Parameters* instead.
+5. Increment the current phase's session counter in the `PROGRESS.md` header and check it against the *Iteration budgets*; if exhausted, escalate.
+6. Proceed per your phase: Phases 0/1 → Section 6; Phases 2/3 → Section 8, picking the **first incomplete task in `PLAN.md`** (read any recorded fix-attempt counters for it first).
+
+Never trust a compaction summary for status — trust the files. Anything not written to them or committed is lost.
+
+## 4. Capability Discovery
+
+Enumerate your available **skills, MCP servers, plugins, subagent types, and plan modes**. Use the best available option per activity; missing → use the fallback, note it once in `PROGRESS.md`. Never block on a missing capability.
+
+| Activity | Prefer | Fallback |
+|---|---|---|
+| Process discipline | **Superpowers skills** (`superpowers:*`): brainstorming → writing-plans → subagent-driven-development / executing-plans, test-driven-development, systematic-debugging, requesting-code-review, verification-before-completion, using-git-worktrees. Invoke by exact name at the points marked below; load the skill, never paraphrase from memory | Inline procedures in this file |
+| Current library docs | **Context7** (`resolve-library-id` → `query-docs`, or `ctx7` CLI) before writing code against any third-party library — never trust training-data API signatures | Official docs via web search |
+| Legacy code navigation | Native LSP or **Serena MCP** (find_symbol, find_referencing_symbols); list all references before changing any public symbol | grep — last resort, strings/config only |
+| Whole-repo overview | **Repomix** (`--compress`) once at Phase 0 start | Directory listing + targeted reads |
+| Parity checks (web UI) | **Playwright CLI** (cheaper) or Playwright MCP: drive the same flow on legacy and new, compare | HTTP-level checks (`curl`); else scripted manual steps for the operator |
+| Database ground truth | Read-only DB MCP (schema, constraints, indexes) before rewriting data access | Schema dump via CLI |
+| History mining | `gh` CLI or GitHub MCP: issue/PR history when legacy behavior looks intentional-but-odd | `git log -L`, `git blame` |
+| Cross-session memory | Repo files (canonical, Section 5); a memory MCP only as a secondary index | Repo files alone |
+
+**Subagents**, if available: use for (a) parallel read-only legacy research, (b) one fresh implementer per plan task, (c) fresh-context reviewers with read-only tools. Every dispatch states: objective, expected output format, tools, out-of-scope boundaries; verify results against Section 1 before accepting. No subagents → same work sequentially, checkpointed in `PROGRESS.md`.
+
+## 5. Artifact Contract (the repo is your memory)
+
+Committed with the code:
+
+- `PLAN.md` — **the single ordered work queue.** Build/test/run commands at the top (legacy commands copied from *Project Parameters*, new-code commands as created). Phased tasks, each small and self-contained: the `FEATURES.json` ids it advances, its failing-test step, implementation step, verification command, commit step. Infrastructure tasks (error taxonomy, logger, config, lint rules) are ordinary tasks here even though they map to no feature.
+- `FEATURES.json` — every legacy behavior: `{id, description, entry_point, tag: KEEP|DROP|CHANGE, approved_behavior?, evidence?, passes: false}`. Default-FAIL. `passes` flips only per Section 8 step 8 (KEEP/CHANGE) or with absence evidence (DROP). Nothing else may change after `APPROVED: phase-0`.
+- `PROGRESS.md` — append-only log; header holds per-phase session counters; first line is reserved for a `BLOCKED:` marker. Every work unit: what changed, evidence (command + result), fix-attempt counters (`task T-12: attempt 2/3 — <approach> — failed`), next step.
+- `DECISIONS.md` — append-only decisions with rationale, plus operator `APPROVED:` lines. Never delete entries.
+- `STANDARDS.md` — Section 7 copied verbatim + approved project-specific additions.
+- `GLOSSARY.md` — the ubiquitous language: one agreed name per domain concept.
+- `SUSPECTED_BUGS.md` — legacy behavior that looks wrong; replicated in the new code, listed here. Never silently "fix" it.
+- `BACKLOG.md` — out-of-scope ideas. New ideas go here, never into code.
+
+**The oracle is frozen at `APPROVED: phase-0`.** Characterization tests and golden-master normalization rules may change afterward only with an operator-approved CHANGE entry referenced in the commit, with the diff logged in `PROGRESS.md`. MIGRATE commits must show an empty `git diff --stat` on test and normalization paths — reviewers check this mechanically.
+
+## 6. Phases (strict order; each gate requires its `APPROVED:` line)
+
+**Phase 0 — Understand (Initializer).**
+First verify the legacy build/run/test commands from *Project Parameters* actually work; record them in `PROGRESS.md`. Map the legacy app: entry points (routes, CLI commands, jobs, handlers), side effects (DB writes, files, network, email), config flags, integrations. Subagents available → dispatch parallel explorers (data model / external interfaces / business rules / test coverage) — *Superpowers: `dispatching-parallel-agents`*. Mine `git blame` and issue history for "why is this weird" code. Then:
+1. Write `FEATURES.json`, tagging KEEP / DROP (with evidence of non-use) / CHANGE (with intended behavior). Blind full parity is a failure mode: reimplementing dead code is as bad as dropping live code.
+2. Write **characterization tests** pinning the legacy app's *observed* behavior for every KEEP feature — run the app, don't guess; assert observed outputs even when they look buggy (log those in `SUSPECTED_BUGS.md`). Where feasible, build a golden-master harness: scripted input corpus + recorded outputs (responses, DB state deltas, files, events), replayable as a diff, with nondeterminism (timestamps, IDs, ordering) normalized. Parity comparisons must run against isolated, identically seeded environments (script seed/reset into `PLAN.md`); if isolation is infeasible, rely on the recorded corpus, not live dual-runs.
+3. Write the `BLOCKED:` marker requesting approval of the tags. **Stop.**
+*Gate: inventory covers 100% of discovered entry points; characterization suite green against untouched legacy; `APPROVED: phase-0` recorded.*
+
+**Phase 1 — Design.**
+*Superpowers: `brainstorming`, then `writing-plans`.* Produce:
+1. `DECISIONS.md` entry: target architecture — Section 7.1's layers mapped to concrete directories under the new repo; the seams where new code intercepts old (router, facade, repository interface).
+2. `STANDARDS.md` and `GLOSSARY.md`.
+3. **Standards-parity reconciliation:** list every observable difference the Section 7 standards will force (e.g. timeouts where the legacy app hung, normalized error payloads, changed log levels) and add each as a CHANGE entry for approval. Parity wins until approved.
+4. `PLAN.md`: vertical slices (one feature/endpoint end-to-end), domain-core-first, written for an executor with zero prior context; exact interfaces between tasks.
+5. Verify every planned third-party API against current docs (Context7).
+6. Write the `BLOCKED:` marker requesting design/plan approval. **Stop.**
+*Gate: `APPROVED: phase-1` recorded.*
+
+**Phase 2 — Execute (strangler-fig).**
+Work on a dedicated branch or worktree (*Superpowers: `using-git-worktrees`*) — never on the default branch. The legacy code is modified **only** at approved seams, plus per-slice deletions after the Parity Gate; it stays runnable as the behavior oracle throughout. One `PLAN.md` task at a time via Section 8:
+- Build the new implementation beside the old; route one slice through it; the app must build, run, and pass the characterization suite after every task, with mixed old/new code.
+- Temporary glue is marked `TRANSITIONAL:` with a written removal condition.
+- Commits are either **MIGRATE** (behavior-preserving; golden master passes exactly; no test/normalization edits) or **SIMPLIFY/CHANGE** (implements an approved CHANGE entry; tests updated accordingly). Never both in one commit.
+- Each piece of state (DB table, file, queue) has exactly one owning path per slice; if both paths must write it, route writes through one shared adapter.
+*Parity Gate per slice: (1) characterization tests green; (2) golden-master diff empty — or, if no golden master was feasible, characterization tests alone — or every diff mapped to an approved CHANGE; (3) error paths exercised, not just happy path; (4) Section 7 self-audit passes. Only then delete that slice's legacy code, recording the gate in the commit/PR description.*
+*Phase exit: every KEEP/CHANGE entry `passes: true`, all slices' legacy code deleted → Phase 3.*
+
+**Phase 3 — Verify and Retire.**
+1. `grep -rn "TRANSITIONAL:" <new-repo>/` → zero; dependency-check (incl. legacy-import ban) passes.
+2. Full characterization + golden-master suite green; every `FEATURES.json` entry `passes: true` with evidence (DROP = absence evidence).
+3. **Final review.** Subagents available → *Superpowers: `requesting-code-review`* with baseline + HEAD SHAs, reviewer explicitly told to check layer boundaries and that no MIGRATE commit touched test/normalization paths. No subagents → a dedicated fresh session whose only work unit is a cold re-read of the full diff against Section 7 and `FEATURES.json`, findings recorded in `PROGRESS.md`; no code edits in that session. Handle findings via *`receiving-code-review`*: verify each claim before acting; push back with evidence on suggestions that reintroduce complexity.
+4. Regenerate the feature inventory as-built; diff against approved — empty except approved changes.
+5. *Superpowers: `verification-before-completion`*: rerun everything fresh, quote actual output. Then *`finishing-a-development-branch`* — the operator chooses merge/PR/keep.
+
+## 7. Coding Standards (The Canon — for all new code)
+
+Distilled from *Clean Architecture*, *Clean Code*, *Software Architecture Patterns*, *Patterns of Enterprise Application Architecture* (PoEAA), *Domain-Driven Design* (DDD), *Design Patterns* (GoF), *Head First Design Patterns* (HFDP), *Effective Java*, *Implementation Patterns*, *Continuous Delivery*, *Refactoring*, *Release It!*, *Building Microservices*, *Production-Ready Microservices*, and Google's *Site Reliability Engineering* (SRE). Copy into `STANDARDS.md`; self-audit each slice before its Parity Gate.
+
+**Precedence:** behavior parity outranks the Canon. Any standard whose application changes observable behavior enters through an approved CHANGE entry (Phase 1 step 3), never unilaterally. Purely internal standards (structure, naming, taxonomy, logger module, correlation IDs) apply unconditionally.
+
+### 7.1 Layers & the Dependency Rule
+- Four layers: **domain** (entities — business rules, pure), **application** (use cases / service layer — orchestrates entities, owns transactions, defines the app boundary), **interface adapters** (controllers, presenters, gateways, mappers), **infrastructure** (frameworks, DB, HTTP — details, outermost). *(Clean Architecture; PoEAA)*
+- Source dependencies point **only inward**; nothing in an inner layer names anything in an outer layer — no functions, classes, or data formats. *(Clean Architecture)*
+- Layers are **closed**: requests pass through the layer immediately below, never skipping. *(Software Architecture Patterns)*
+- Crossing against the flow: inner layer declares the interface (port), outer layer implements it (adapter) — Dependency Inversion. *(Clean Architecture)*
+- Only simple, isolated DTOs cross boundaries — never entities, raw DB rows, or framework objects. *(Clean Architecture; PoEAA)*
+- Don't marry the framework: no framework base classes in domain code; the database is a detail. *(Clean Architecture)*
+- **Enforce mechanically**: an import-linter / dependency-check rule in the build (ecosystem's standard tool) makes any layer violation — or any new-code import of a legacy module — a build failure.
+
+### 7.2 Presentation (MVC)
+- Model holds data, state, and business logic; View only displays; Controller interprets input, manipulates the Model, selects the View. *(HFDP; PoEAA)*
+- The Model never depends on the presentation; it notifies views via Observer. No domain logic in views — a view needing a decision calls a domain method (e.g. `isSalesImproving()`), never computes it. *(PoEAA; HFDP)*
+- Simple pages → Page Controller; complex navigation/security → Front Controller; machine-dictated screen flow → Application Controller. Don't add one you don't need. *(PoEAA)*
+
+### 7.3 Reusable Components
+- Program to an interface, not an implementation; favor composition over inheritance; encapsulate what varies. *(GoF; Effective Java; HFDP)*
+- SOLID: one reason to change per module (SRP); extend by adding code, not modifying working code (OCP); depend on abstractions (DIP). *(Clean Architecture; Clean Code)*
+- Group classes released together (REP) and changing together (CCP); don't force users to depend on things they don't use (CRP). *(Clean Architecture)*
+- DRY: duplication is the primary enemy — extract shared abstractions; replace repeated switch/if chains with polymorphism. Many small classes and functions that do one thing; one level of abstraction per function. *(Clean Code)*
+- **Search before implementing** — the component may already exist. Extend the shared modules (error taxonomy, logger, config); never create parallel mechanisms.
+
+### 7.4 Entities, Value Objects, DTOs, Naming
+- Entity = identity + lifecycle + invariants; Value Object = immutable, equality by fields, freely shareable; DTO = flat serializable boundary shape, no logic. Map between them only at layer boundaries via explicit mappers/assemblers. *(DDD; PoEAA; Clean Code)*
+- Invalid objects are unconstructible: invariants enforced in complete constructors or factories. Entities cluster into aggregates; external access only through the aggregate root. *(DDD; Implementation Patterns)*
+- Ubiquitous language: one name per concept (`GLOSSARY.md`), identical in code, DB, API, docs; intention-revealing, pronounceable names; no abbreviations, prefixes, or Hungarian encodings. Suffix scheme: `*Request`/`*Response` (transport), `*Record` (persistence), bare noun (entity). *(DDD; Clean Code)*
+
+### 7.5 Constants & Configuration
+- No magic numbers or strings: every meaningful literal is a named, searchable constant, defined once, placed where a reader expects it. Related constants → enums, never int/string constants; never constant interfaces. *(Clean Code; Effective Java; Implementation Patterns)*
+- Environment-dependent values are configuration, not code: same binary in every environment; config read and validated at startup into one typed Config object (missing key = immediate startup failure with a clear message); no ad-hoc env reads mid-execution; defaults held at the highest level and passed down. *(Continuous Delivery; Clean Code)*
+- Config files under version control; secrets never in code, VCS, logs, or exception messages — injected at deploy time. *(Continuous Delivery; Effective Java)*
+
+### 7.6 Error Handling
+- One error taxonomy module in the domain/application layer: base `AppError` (code, message, context, cause) with a small closed set of subclasses (Validation, NotFound, Conflict, Auth, ExternalService, Internal).
+- Exceptions, not return codes; define exception classes by how callers must respond; every exception carries the values that produced it. *(Clean Code; Effective Java)*
+- Never swallow: no empty catch blocks; catch only to translate, enrich, or handle-and-log with the original attached as cause. *(Effective Java)*
+- Never return or pass null: empty collections, Special Case objects, or Optionals. *(Clean Code; Effective Java)*
+- Adapters translate third-party errors into taxonomy errors at the boundary; inner layers never see vendor exception types. *(Clean Code; Effective Java)*
+- Fail fast on invariant violations and invalid input. At integration points apply Timeouts, Circuit Breakers, Bulkheads *(Release It!)* — these change observable failure behavior, so they enter via approved CHANGE entries. Top-level handlers (HTTP layer, job runner) are the only place errors become responses/exit codes, mapping error code → status.
+
+### 7.7 Logging & Observability
+- One logging module wrapping the platform logger; direct print/console output is banned. Structured key-value/JSON with fixed base fields: timestamp, level, service, correlation_id, event code, duration where relevant. Static event names with data in fields, not interpolated prose. *(Release It!; SRE)*
+- Correlation ID generated at every entry point, propagated through all layers and outbound calls. *(Building Microservices; SRE)*
+- Levels: ERROR = failed operation needing operator action only (bad user input is WARN at most); INFO = significant state transitions and boundary entry/exit with outcome + duration; DEBUG off in production. *(Release It!)*
+- Never log secrets, tokens, or sensitive user data. *(Effective Java; Release It!)*
+- Design for — but do not deploy — log rotation/aggregation and four-golden-signals monitoring (latency, traffic, errors, saturation; alert on symptoms, not causes): keep the code aggregation-ready; the infrastructure itself is out of scope. *(Release It!; Production-Ready Microservices; SRE)*
+
+## 8. The Work-Unit Loop (Phases 2–3)
+
+Exactly **one** work unit — the first incomplete task in `PLAN.md` — per session. Finish, verify, commit, log, stop; even if you have time for more.
+
+1. **Pick** the first incomplete `PLAN.md` task. Read its recorded fix-attempt counter.
+2. **Drift check**: re-read Section 1; write one line in `PROGRESS.md`: how this task serves the goal. Can't answer → stop; re-plan against Section 1 or escalate.
+3. **Search first**: confirm the needed code doesn't already exist in the new repo.
+4. **TDD** (*Superpowers: `test-driven-development`*): red → green → refactor. For migration tasks, expected values come from the legacy app's *observed* behavior — run it. No production code without a failing test first (wrote some anyway? delete it, restart the cycle). No placeholders or stubs.
+5. **Verify**: full test suite + an end-to-end check through the real UI/API (Playwright/HTTP). Failing tests unrelated to your change are also your job. Bug or divergence from legacy → *Superpowers: `systematic-debugging`* — root cause first, legacy implementation as the working reference. Log each attempt (`attempt N/3`) in `PROGRESS.md`; the counter is cumulative across sessions — at 3, escalate.
+6. **Standards self-audit** of touched code against Section 7.
+7. **Review**: subagents → fresh reviewer (*Superpowers: `requesting-code-review`*) with baseline + HEAD SHAs and task requirements only. No subagents → before committing, re-read the full diff cold against the task requirements and Section 7; record findings. Critical/Important findings (defined in Section 2) block.
+8. **Record evidence** in `PROGRESS.md` (actual command + result). Flip a feature's `passes` to `true` only when its slice clears the Parity Gate.
+9. **Commit** (MIGRATE or SIMPLIFY/CHANGE — never both), update artifacts, stop.
+
+Under an outer loop, the mechanical stop is Section 2 — or a `BLOCKED:` marker. Fix problems by editing plan/spec files between iterations, never by mutating this prompt.
+
+## 9. Guardrails & Escalation
+
+**Prohibitions (hard rules):**
+- Never big-bang: the app must build, run, and pass the characterization suite after every task.
+- Never delete a slice's legacy code before its Parity Gate; never touch the legacy app otherwise, except at approved seams.
+- Never delete, weaken, or edit a test, a normalization rule, or a `FEATURES.json` entry to get to green; the oracle is frozen (Section 5) — changes require an approved CHANGE entry.
+- Never drop or "fix" inexplicable legacy logic on your own judgment — replicate it, record it in `SUSPECTED_BUGS.md`. Equivalence is proven only by legacy-derived tests, never by tests written against the new code's own behavior.
+- Never add features, endpoints, options, or "improvements" absent from `FEATURES.json` — ideas go to `BACKLOG.md`.
+- Never write an `APPROVED:` line. Never commit secrets. Never force-push, push, or merge without operator instruction.
+
+**Escalate — write `BLOCKED: <one-line question>` as the first line of `PROGRESS.md`, add context below, and exit — when:**
+(a) a change would require editing Section 1, a `FEATURES.json` entry, or a recorded decision; (b) the same failure persists after 3 cumulative fix attempts; (c) an action is destructive or irreversible (data migration, deleting user data, force-push, auth/billing changes); (d) two requirements conflict; (e) a phase/slice iteration budget (*Project Parameters*) is exhausted; (f) a phase gate needs operator approval. Only the operator removes a `BLOCKED:` line.
+
+---
+
+## Operator's answers (session 1, 2026-08-09)
+
+- App to rewrite: **both** `src/timecapsulesmb/` (Python CLI) and `macos/TimeCapsuleSMB/` (SwiftUI GUI)
+- New code location: **new repo** `../apple-time-capsule-utils` (= `/Users/felipe.dos.santos/code/apple-time-capsule-utils`), no legacy code in it
+- Target stack: same language/framework, latest stable versions
+- Out of scope: default — no new features, no UI redesign, no DB migration (plus: on-device `assets/boot/samba4/*` and `bin/` binaries are payload data, not rewritten; no `build/` VM work)
+- AGENTS.md handling: keep existing repo AGENTS.md intact; this file is `AGENTS-REWRITE.md` beside it
+- Iteration budgets: defaults (Phase 0 ≤ 10; Phase 1 ≤ 5; Phase 2 ≤ 5/slice; Phase 3 ≤ 5)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+TimeCapsuleSMB deploys a modern Samba 4 server onto Apple AirPort Time Capsules (NetBSD 6 / NetBSD 4 firmware). Two parts: a Python CLI (`src/timecapsulesmb/`, package `timecapsulesmb`) and a SwiftUI macOS GUI (`macos/TimeCapsuleSMB/`). The Python side is what actually talks to devices; the GUI is a front end for it.
+
+> **Active rewrite:** this repo is the frozen behavior oracle of a clean-architecture rewrite that now lives at `https://github.com/felipe-dos-santos81/apple-time-capsule-utils` (workflow: `AGENTS-REWRITE.md`; CI green across Python 3.12/3.14 + Swift as of 2026-08-10). Do not restructure this repo's architecture or rename public symbols — the rewrite's characterization suite pins them. Fix bugs here if they affect the rewrite, but keep changes scoped.
+
+## Setup and verification
+
+- `./tcapsule bootstrap` is the **only** repo-root launcher command. It builds `.venv` and installs the `tcapsule` console script. After that, always use `.venv/bin/tcapsule ...` — the root `tcapsule` script just `execv`s the venv binary and refuses anything else (tcapsule:51).
+- **Gotcha:** `./tcapsule bootstrap` installs base deps only — ruff, pytest-xdist, and coverage come from the `[dev]` extras (`pyproject.toml`). `make lint`/`make test` fail with `No module named ruff` until `.venv/bin/pip install -e ".[dev]"`. `make install` does both (bootstrap + dev extras) and is a prerequisite of every other Makefile target.
+- Full verification: `make test-parallel` (C compile checks + pytest-xdist with `--dist loadfile`). For focused debugging use single-process `.venv/bin/pytest tests/test_foo.py`.
+- Device workflow stages are Makefile targets, numbered by stage: `make install` → `discover`/`validate-install` → `configure` → `deploy`/`deploy-dry-run` → `activate`/`flash-backup`/`flash-patch`/`flash-restore` → `doctor` → `fsck`/`repair-xattrs` → `uninstall`/`uninstall-dry-run` → `set-ssh` (`make help` lists all). Variables: `yes=1`/`json=1`/`dry=1` pass `--yes`/`--json`/`--dry-run`; deploy/fsck/uninstall also accept `no-reboot=1`; `flash-restore` accepts `reboot=1`. `make test`/`test-parallel` also run `test-c`.
+- Lint: `make lint` (ruff on `src tests macos/TimeCapsuleSMB/tools tcapsule`; config: py39 target, line-length 100, only E9/F63/F7/F82 selected).
+- Swift tests are macOS-only: `swift test --package-path macos/TimeCapsuleSMB`. **Environment quirk:** requires full Xcode — machines with only CommandLineTools fail with `no such module 'XCTest'`; protocol-level characterization of the `tcapsule api` backend is the fallback.
+- If any checked-in binary under `bin/` changes, update `src/timecapsulesmb/assets/artifact-manifest.json` and run `pytest tests/test_artifacts.py tests/test_artifact_resolver.py`.
+- CI matrix (`.github/workflows/ci.yml`): Ubuntu+macOS × Python 3.9/3.12/3.14, plus a Swift test job and a `package_app.py` packaging job.
+
+## Architecture (non-obvious wiring)
+
+- Entry point `src/timecapsulesmb/cli/main.py` dispatches one module per command (`deploy.py`, `flash.py`, `doctor.py`, `configure.py`, ...) sharing `cli/context.py` (CommandContext). Every command except `api` runs a version gate that fetches GitHub (3h cache) before dispatch.
+- The macOS app never talks to devices directly. `Backend/BackendClient.swift` spawns the Python `tcapsule api` backend (`cli/api.py` → `app/helper.py` → `app/service.py`) as a subprocess speaking a JSON-lines protocol over pipes (`app/events.py`, `app/requests.py`). `TCAPSULE_HELPER` env overrides the helper path. Import-boundary tests enforce `app/` must not import `cli/` (tests/test_import_boundaries.py).
+- On-device runtime is POSIX sh under `src/timecapsulesmb/assets/boot/samba4/`: `manager.sh` orchestrates numbered `common.d/*.sh` steps. These files are copied to real devices — changes run on the Time Capsule. Host-side flows and the on-device manager are two parallel state machines that agree only via string-matched log lines, exit codes, and fixed paths.
+- `bin/` holds prebuilt statically-compiled NetBSD binaries (smbd, mdns/nbns advertisers, rsync) for three families: `netbsd6` (NetBSD 6), `netbsd4le`/`netbsd4be` (NetBSD 4 little/big endian). Rebuilding requires the NetBSD VM flow under `build/` (takes hours) — do not rebuild casually.
+- `build/mdns-advertiser.c` and `build/nbns-advertiser.c` are compile-checked only (`make test-c` compiles them to /tmp).
+
+## Device constraints (mandatory for on-device code)
+
+- No pthread on the device. NetBSD 4 has a tiny userspace: do not assume `awk`, `grep`, `tr`, `cut`, `wc`, or `scp` exist on-device.
+- Runtime shell helpers must use explicit `|| return 1` checks — NetBSD 4 `/bin/sh` does not reliably enforce `set -e` inside functions called from conditional contexts.
+- Storage: `/mnt/Flash` is persistent but ~900KB (only small loader scripts live there); `/mnt/Memory` is a 16MB ramdisk Samba runs from; the internal HDD is large but unmounts when idle. Avoid new runtime state files unless truly required across process boundaries.
+
+## Conventions and gotchas
+
+- `tcapsule configure` writes `.env` in the repo root (gitignored) with `TC_HOST`/`TC_PASSWORD`. Never commit `.env`, device logs, or logs containing passwords/IPs/serial numbers.
+- Telemetry is on by default; `tests/conftest.py` blocks unmocked telemetry posts.
+- Keep changes scoped to one behavior; do not remove doctor tests (CONTRIBUTING.md).
+- The big fixture-heavy test files hold most behavior tests — prefer adding cases there over new per-module files: `tests/test_cli.py` (~8900 lines), `tests/test_deploy_modules.py` (~8900), `tests/test_storage_runtime.py` (~7000, on-device pure-shell MaSt parser vs golden fixtures), `tests/test_app_api.py` (~4700, the api protocol contract pin), `tests/test_checks.py` (~5500, doctor checks).
+- Device behavior is faked per-test via `mock.patch` of `run_ssh`/transport functions; there is no shared fake-device class. `tests/storage_fixtures.py` holds golden MaSt outputs.
+
+## Graphify helper
+
+A prebuilt knowledge graph of this repo lives in `graphify-out/` (not committed; regenerate with the /graphify skill). For architecture questions run `graphify query "<question>"`; `graphify-out/GRAPH_REPORT.md` lists communities, god nodes, and surprising connections, and `graph.html` is the interactive view. The graph is rebuilt from the current tree, so use it for orientation but verify against code before making changes.

--- a/Makefile
+++ b/Makefile
@@ -1,75 +1,133 @@
-# TimeCapsuleSMB Makefile
-#
-# Prerequisites:
-#   - macOS or Linux: Python 3 and smbclient for configure/deploy/doctor
-#
-# Quick start:
-#   1) ./tcapsule bootstrap
-#   2) .venv/bin/tcapsule configure
-#   3) .venv/bin/tcapsule deploy
-#   4) .venv/bin/tcapsule doctor
-#
-# Targets:
-#   make venv                    - create local virtualenv at .venv
-#   make install                 - install Python dependencies into .venv
-#   make lint                    - run Ruff against Python sources and tests
-#   make test                    - run C compile checks and Python pytest suite
-#   make test-parallel           - run C compile checks and pytest-xdist suite
-#   make coverage                - run Python tests with coverage and show missing lines
-#   make coverage-html           - write an HTML coverage report to htmlcov/
-#   make test-c                  - compile-check mdns/nbns helper sources
-#   make discover                - run tcapsule discover (depends on install)
-#   make bootstrap-host          - run the host bootstrap helper
-#   make set-ssh                 - advanced SSH toggle helper
-#   make clean                   - remove the .venv directory
+# Makefile for TimeCapsuleSMB — Deploy modern Samba onto Apple AirPort Time Capsules
+# Targets are numbered by workflow stage:
+#   install → 1 discover → 2 configure → 3 deploy → 4 activate/flash →
+#   5 doctor → 6 fsck/repair → 7 uninstall → dev
+SERVICE = TimeCapsuleSMB
 
-.PHONY: venv install lint test test-parallel coverage coverage-html test-c discover bootstrap-host set-ssh setup clean
+# Variables
+VENV_DIR = .venv
+PY = $(VENV_DIR)/bin/python
+PIP = $(VENV_DIR)/bin/pip
+T = $(VENV_DIR)/bin/tcapsule
 
-VENVDIR := .venv
-PYTHON := python3
-PIP := $(VENVDIR)/bin/pip
-PY := $(VENVDIR)/bin/python
+.PHONY: help install clean \
+        discover validate-install \
+        configure \
+        deploy deploy-dry-run \
+        activate flash-backup flash-patch flash-restore \
+        doctor \
+        fsck repair-xattrs \
+        uninstall uninstall-dry-run \
+        lint test test-parallel test-c coverage coverage-html set-ssh
 
-venv:
-	$(PYTHON) -m venv $(VENVDIR)
-	@echo "Run: source $(VENVDIR)/bin/activate"
+# ── Environment ──────────────────────────────────────────────────────────────
 
-install: venv
-	$(PIP) install -U pip
-	$(PIP) install -r requirements.txt
-	$(PIP) install -e ".[dev]"
+help: ## Print this help message
+	@printf '\033[01;32m${SERVICE} — Deploy modern Samba onto AirPort Time Capsules\033[00;37m\n\n'
+	@printf "\033[33mUsage:\033[0m\n  make [target] [yes=1] [json=1] [dry=1] [no-reboot=1] [reboot=1]\n\n\033[33mTargets:\033[0m\n"
+	@grep -E '^[-a-zA-Z0-9_\.\/]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; \
+		{printf "  \033[36m%-26s\033[0m %s\n", $$1, $$2}'
 
-lint: install
+install: ## Bootstrap the .venv (python deps, editable install, host tools)
+	@if [ ! -d "$(VENV_DIR)" ]; then \
+		./tcapsule bootstrap; \
+	fi; \
+	$(PIP) install -e ".[dev]"; \
+	echo "Environment ready: $(T)"
+
+clean: ## Remove .venv and all temporary/generated files
+	rm -rf $(VENV_DIR)
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	rm -rf .pytest_cache .ruff_cache .coverage htmlcov
+	@echo "Cleanup complete."
+
+# ── Stage 1 · Discover (mDNS/Bonjour) ─────────────────────────────────────────
+
+discover: install ## [STEP  1] List all mDNS/Bonjour devices on the network (json=1 for machine-readable output)
+	@echo "Discovering devices..."
+	$(T) discover $(if $(json),--json)
+
+validate-install: install ## [STEP  1] Validate the local install (binaries, artifacts, venv state)
+	$(T) validate-install $(if $(json),--json)
+
+# ── Stage 2 · Configure (writes .env) ─────────────────────────────────────────
+
+configure: install ## [STEP  2] Configure the device and write .env (yes=1 approves enabling SSH via ACP)
+	@echo "Configuring device..."
+	$(T) configure $(if $(yes),--yes)
+
+# ── Stage 3 · Deploy ──────────────────────────────────────────────────────────
+
+deploy: install ## [STEP  3] Deploy/update Samba onto the device (yes=1 skips reboot prompt; no-reboot=1 activates in place)
+	@echo "Deploying to device..."
+	$(T) deploy $(if $(yes),--yes) $(if $(no-reboot),--no-reboot)
+
+deploy-dry-run: install ## [STEP  3] Print the deployment plan without changing the device (json=1 for machine-readable output)
+	@echo "Dry-run deployment plan..."
+	$(T) deploy --dry-run $(if $(json),--json)
+
+# ── Stage 4 · Boot hook (NetBSD 4) — activate or flash ────────────────────────
+
+activate: install ## [STEP  4] Start the deployed Samba runtime now (yes=1 skips the restart prompt)
+	$(T) activate $(if $(yes),--yes)
+
+flash-backup: install ## [STEP  4] Back up and inspect the firmware banks (no write; json=1 for machine-readable output)
+	@echo "Backing up flash memory..."
+	$(T) flash $(if $(json),--json)
+
+flash-patch: install ## [STEP  4] Patch the primary firmware bank LOGIN boot hook (yes=1 skips the write prompt)
+	@echo "Patching firmware boot hook..."
+	$(T) flash --patch $(if $(yes),--yes)
+
+flash-restore: install ## [STEP  4] Restore a firmware bank from Apple stock firmware (yes=1 skips the write prompt; reboot=1 reboots after)
+	@echo "Restoring firmware bank..."
+	$(T) flash --restore $(if $(yes),--yes) $(if $(reboot),--reboot)
+
+# ── Stage 5 · Doctor (verify the result) ──────────────────────────────────────
+
+doctor: install ## [STEP  5] Non-destructive diagnostic of the deployed runtime (json=1 for machine-readable output)
+	$(T) doctor $(if $(json),--json)
+
+# ── Stage 6 · Maintenance (fsck / xattr repair) ───────────────────────────────
+
+fsck: install ## [STEP  6] Repair the internal disk before deploy (yes=1 skips the prompt; no-reboot=1 runs fsck only)
+	$(T) fsck $(if $(yes),--yes) $(if $(no-reboot),--no-reboot)
+
+repair-xattrs: install ## [STEP  6] Repair broken xattrs on the disk (yes=1 repairs without prompting; dry=1 only scans)
+	$(T) repair-xattrs $(if $(yes),--yes) $(if $(dry),--dry-run)
+
+# ── Stage 7 · Uninstall ───────────────────────────────────────────────────────
+
+uninstall: install ## [STEP  7] Remove TimeCapsuleSMB from the device (yes=1 skips the reboot prompt; no-reboot=1 keeps it running)
+	$(T) uninstall $(if $(yes),--yes) $(if $(no-reboot),--no-reboot)
+
+uninstall-dry-run: install ## [STEP  7] Print the uninstall plan without changing the device (json=1 for machine-readable output)
+	@echo "Dry-run uninstall plan..."
+	$(T) uninstall --dry-run $(if $(json),--json)
+
+# ── Development ───────────────────────────────────────────────────────────────
+
+lint: install ## Run the Ruff linter (py39 target, E9/F63/F7/F82 only)
 	$(PY) -m ruff check src tests macos/TimeCapsuleSMB/tools tcapsule
 
-test: install test-c
-	$(PY) -m pytest
+test: install test-c ## Run the pytest unit test suite (single process)
+	$(PY) -m pytest -q
 
-test-parallel: install test-c
+test-parallel: install test-c ## Run the pytest suite with xdist (C compile checks + pytest -n auto --dist loadfile)
 	$(PY) -m pytest -n auto --dist loadfile
 
-coverage: install
-	$(PY) -m coverage run -m pytest
-	$(PY) -m coverage report
-
-coverage-html: coverage
-	$(PY) -m coverage html
-	@echo "Open htmlcov/index.html to inspect line-by-line coverage."
-
-test-c:
+test-c: ## Compile-check the mdns/nbns advertiser C sources (outputs to /tmp)
 	cc -Wall -Wextra -Werror -o /tmp/mdns-advertiser-test build/mdns-advertiser.c
 	cc -Wall -Wextra -Werror -o /tmp/nbns-advertiser-test build/nbns-advertiser.c
 
-discover: install
-	$(VENVDIR)/bin/tcapsule discover
+coverage: install ## Run tests with coverage and show missing lines
+	$(PY) -m coverage run -m pytest
+	$(PY) -m coverage report
 
-bootstrap-host:
-	./tcapsule bootstrap
+coverage-html: coverage ## Write an HTML coverage report to htmlcov/
+	$(PY) -m coverage html
+	@echo "Open htmlcov/index.html to inspect line-by-line coverage."
 
-set-ssh: install
-	$(VENVDIR)/bin/tcapsule set-ssh
-
-setup: install
-
-clean:
-	rm -rf $(VENVDIR)
+set-ssh: install ## Advanced SSH enable/disable helper (yes=1 skips the legacy prompt)
+	$(T) set-ssh $(if $(yes),--yes)

--- a/README.md
+++ b/README.md
@@ -4,385 +4,85 @@
 [![Latest Release](https://img.shields.io/github/v/release/jamesyc/TimeCapsuleSMB)](https://github.com/jamesyc/TimeCapsuleSMB/releases/latest)
 [![License](https://img.shields.io/github/license/jamesyc/TimeCapsuleSMB)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](pyproject.toml)
-[![macOS App](https://img.shields.io/badge/macOS%20app-download-brightgreen)](https://github.com/jamesyc/TimeCapsuleSMB/releases/latest)
 
-Apple AirPort Time Capsules only support AFP and SMB1 natively. Apple removed AFP support in macOS 27 (and removed SMB1 support from macOS a long time ago). This is a modern Samba setup that runs directly on the Time Capsule itself; macOS 27 can connect to the Time Capsule as a network share, and use it for Time Machine backups. 
+Apple AirPort Time Capsules only speak AFP and SMB1 natively. macOS removed SMB1 support long ago (and AFP in macOS 27), so modern macOS can no longer back up to a stock Time Capsule. TimeCapsuleSMB runs a modern Samba 4 server **on the Time Capsule itself**: the device advertises itself over Bonjour (it appears automatically in Finder → Network), accepts authenticated SMB3 connections, and works as a Time Machine destination — even if its IP address changes.
 
-This project has 2 parts:
-- a fork of Samba 4, modified to work on the Apple Time Capsule 
-- the installers for the Samba binary, via terminal or the **macOS GUI app**. 
+This project has two parts:
 
-The Time Capsule will run its own Samba 4.24.3 server, advertise itself over Bonjour (show up automatically in the "Network" folder on macOS), and accept authenticated SMB3 connections. You can open Finder, choose Connect to Server, and use a normal SMB URL without relying on Apple’s legacy stack. You can also use the disk for Time Machine backups:  
-<img width="478" height="268" alt="image" src="https://github.com/user-attachments/assets/c713a1c6-ff71-43a2-a057-451223a1c0e0" />  
-You get the full Apple experience reproduced: after you install this, you do not have to worry about it again, even if the device IP address changes. It will show up automatically in the Time Machine section in the Settings app, and it will use mDNS/Bonjour so it will work fine even if the IP address is not static and gets changed.
-
-The "Install" or `deploy` script will install files in `/mnt/Flash` on the Time Capsule, plus a `.samba4` folder on the root of the hard drive. The `uninstall` script removes those managed files and can optionally reboot the device afterward.
-
-NetBSD 6 devices automatically startup on boot. **Older NetBSD 4 devices may need a manual `activate` after every reboot**, or you can **use this to flash the firmware (to add a boot hook) to allow it to automatically start Samba on reboot**. If you do not flash the boot hook, then Samba will not start automatically on an older Time Capsule!
-
-The current authentication model accepts any user as the username, and the Samba password is the current Time Capsule device password. At boot, the device reads its live AirPort `syPW` value and generates the Samba password file in RAM, so a device-password change is picked up after reboot. Guest access is disabled.
-
-AirPort Extreme devices are not officially supported. Unofficially, they work fine. Note that this is installed to the hard drive, so it will not work for an Airport Extreme without a hard drive (as there is not enough space to store the binaries on the flash memory).   
-
-If TimeCapsuleSMB has been useful to you, you can [buy me a coffee](https://buymeacoffee.com/jamesyc) to support the project.
+- a fork of Samba 4, prebuilt as static binaries for the device (in `bin/`)
+- the installers for those binaries: a Python CLI (`tcapsule`) and a macOS GUI app
 
 ## Requirements
 
-You will need:  
-- A macOS 14+ or Linux machine on the same local network as the Time Capsule
-- The password for the Time Capsule
+- A Mac (macOS 14+) or Linux machine on the same local network as the Time Capsule
+- The Time Capsule password
+- Python 3.9+; `smbclient` for `doctor` (and `sshpass` for NetBSD 4 devices) — installed automatically when possible
 
-For the python setup, you need:  
-- Python 3.9+
-- `smbclient` installed locally for `doctor`
-- Homebrew installed for macOS users
-
-During first-time setup, if necessary `configure` can enable SSH on the Time Capsule.
-
-Also, if you are an expert and want to DIY the install, you can copy the binary at [/bin/samba4/smbd](/bin/samba4/smbd) for NetBSD 6 devices, [/bin/samba4-netbsd4le/smbd](/bin/samba4-netbsd4le/smbd) for NetBSD 4 little-endian devices, or [/bin/samba4-netbsd4be/smbd](/bin/samba4-netbsd4be/smbd) for NetBSD 4 big-endian devices onto the Time Capsule and set it up yourself. The binaries are statically compiled, so you don't need anything else. The working binaries are saved in this repository under [bin/](bin), and the normal user workflow uses those checked-in files directly. You do not need to build Samba yourself, but if you want to rebuild `smbd` by yourself, run the scripts in `build/` on a NetBSD machine. 
+AirPort Extreme devices are not officially supported (no hard drive, so not enough space for the binaries).
 
 ## Quick Start (macOS app)
 
-1. Download the latest release of the app from here: https://github.com/jamesyc/TimeCapsuleSMB/releases
-2. Unzip the app and run it. If you get a "cannot be opened" warning, you need to manually disable Gatekeeper for this app.
-3. Make sure *Local Network* permissions is granted (System Settings → Privacy & Security → Local Network → make sure TimeCapsuleSMB is allowed, then quit/reopen the app). Close and re-open the app after granting permissions.
-4. Click "Add Device" on the left sidebar, and select your device. 
-5. Enter your device password, and click "Save Device". 
-6. Wait for the app to enable SSH for your Time Capsule.
-    - If it fails, close the app, reopen the app, remove the saved device, and try again.
-    - Also, try rebooting your device.
-7. Click the added device in the left sidebar, and then click on the "Install/Update" tab.  
-   <img width="543" height="390" alt="image" src="https://github.com/user-attachments/assets/ea17ef0e-7624-4a06-888c-72ba6f8d4f8f" />  
-8. Click "Install/Update" to deploy to the device.  
-   <img width="544" height="390" alt="image" src="https://github.com/user-attachments/assets/49975391-29e5-46df-b249-2a75762983a7" />    
-    - If deploying to the device fails, try removing the saved device from the app, then go back to step 4 above to "Add Device" again. It sometimes takes more than one deploy to copy all the files over.
-    - There are reports the device may reset during a deploy, see [this issue](https://github.com/jamesyc/TimeCapsuleSMB/issues/177) for more information.
-9. (For gen 1-4 devices only) Go to the maintenance page "Persistent NetBSD4 Boot Hook" section. Install the firmware patch to allow the device to automatically start Samba after reboots. Click "Back Up and Inspect" and "Plan Patch" to check if it can be installed; then run "Write Patch" to flash it to your device.    
-   <img width="634" height="429" alt="image" src="https://github.com/user-attachments/assets/e35d8934-975b-4079-8087-8c22984a3165" />
-10. (Optional) Wait 5-10 minutes for Samba to fully start up, then go to the Checkup tab and run a Checkup.
+1. Download the latest release, unzip, and open it (disable Gatekeeper if prompted).
+2. Grant Local Network permission (System Settings → Privacy & Security → Local Network), then quit and reopen the app.
+3. Add Device, select your Time Capsule, enter its password, and Save Device.
+4. Click Install/Update on the device's Install tab. (If deploy fails, remove the saved device and add it again — it sometimes takes more than one deploy.)
+5. Gen 1–4 devices only: on the Maintenance page, install the "Persistent NetBSD4 Boot Hook" (Back Up and Inspect → Plan Patch → Write Patch) so Samba auto-starts after reboots.
+6. Optional: wait 5–10 minutes for Samba to start, then run a Checkup.
 
-Please [read the FAQ](FAQ.md) for more information. If you have an issue that could not be resolved via the FAQ, I would appreciate it if you [file an issue here](https://github.com/jamesyc/TimeCapsuleSMB/issues) for help.
-
-## Quick Start (with python)
-
-Download (or run `git clone`) this repository to a folder on your Mac or Linux machine.
-
-From the root of this repository, the normal quick start commands to run are:
-
-1. `./tcapsule bootstrap`
-2. `.venv/bin/tcapsule configure` save a config/settings file
-3. `.venv/bin/tcapsule deploy` deploy to the Time Capsule according to the config file
-4. `.venv/bin/tcapsule doctor` check if everything is working
-5. `.venv/bin/tcapsule flash` to backup the flash memory, and `.venv/bin/tcapsule flash --patch` to patch it
-
-If you run into any issues:
-
-- `.venv/bin/tcapsule activate` after reboot on NetBSD 4 devices if Samba did not auto-start
-- `.venv/bin/tcapsule fsck` if the internal disk needs repair before deploy
-- `.venv/bin/tcapsule discover` to list all mDNS/Bonjour devices
-- `.venv/bin/tcapsule repair-xattrs` to repair any broken files on the disk from bad xattrs
-- `.venv/bin/tcapsule uninstall` if you want to remove TimeCapsuleSMB later
-
-Just delete this `TimeCapsuleSMB` folder if you want to remove it from your Mac after you're done setting up the Time Capsule. All the scripts/binaries/etc are stored in the `TimeCapsuleSMB` folder (so if you want to clean up your Mac, then just deleting the folder is fine).
-
-If you find any bugs, I would appreciate it if you [file an issue here](https://github.com/jamesyc/TimeCapsuleSMB/issues) for help.
-
-## Step 1: Prepare Your Host
-
-Run:
+## Quick Start (Python CLI)
 
 ```bash
-./tcapsule bootstrap
+./tcapsule bootstrap               # the only repo-root command; builds .venv
+.venv/bin/tcapsule configure       # discovers the device, enables SSH if needed, writes .env
+.venv/bin/tcapsule deploy          # installs Samba on the device
+.venv/bin/tcapsule doctor          # verifies everything works
 ```
 
-This command prepares the local Python environment in this folder. It creates the `.venv` folder, installs the Python dependencies needed for discovery, deployment, and verification, and sets up the local `tcapsule` command into that virtualenv.
+### Commands
 
-If `smbclient` or `sshpass` is missing, `bootstrap` will try to install it with Homebrew on macOS 14+ or the detected package manager on Linux. Older macOS versions can continue only when `smbclient` and `sshpass` are already installed manually. NetBSD 4 devices need `sshpass` because their firmware does not provide a usable remote `scp`.
+| Command | Purpose |
+|---|---|
+| `configure` | Discover the device (mDNS/Bonjour), enable SSH via ACP if closed, write `.env` |
+| `deploy` | Install/update Samba; reboots by default (`--yes`, `--no-reboot`, `--dry-run --json`) |
+| `activate` | Start the deployed runtime without re-copying (needed after every reboot on NetBSD 4) |
+| `flash` | Back up flash memory; `--patch` installs the persistent boot hook (unplug to reboot after success); `--restore` restores a bank from Apple stock firmware; `--check-apple` verifies banks |
+| `fsck` | Repair the internal disk before deploy |
+| `doctor` | Non-destructive diagnostics (`--json`) |
+| `discover` | List mDNS/Bonjour devices (`--json`) |
+| `repair-xattrs` | Repair broken on-disk xattrs |
+| `uninstall` | Remove Samba and boot files (`--yes`, `--no-reboot`, `--dry-run --json`) |
+| `validate-install`, `paths`, `set-ssh` | Local install checks and helpers |
 
-If this is your first time using the repo, this is the only command you should run with the repo-local launcher. After this step, use `.venv/bin/tcapsule ...` to run a command.
+The same workflow is available as numbered Makefile stages — `make install` → `discover`/`validate-install` → `configure` → `deploy`/`deploy-dry-run` → `activate`/`flash-backup`/`flash-patch`/`flash-restore` → `doctor` → `fsck`/`repair-xattrs` → `uninstall`/`uninstall-dry-run` → `set-ssh` (see `make help`; `yes=1`/`json=1`/`dry=1`/`no-reboot=1`/`reboot=1` pass the corresponding flags).
 
-You can inspect the local repo-only install before continuing:
+## How it works
 
-```bash
-.venv/bin/tcapsule paths
-.venv/bin/tcapsule validate-install
-```
+The Time Capsule hardware is old and constrained, with three storage areas:
 
-## Step 2: Create The Local Config
+- `/mnt/Flash` — persistent, ~900 KB free: only a small boot loader lives here
+- `/mnt/Memory` — 16 MB ramdisk: the Samba runtime runs from here
+- Internal HDD — large, but Apple unmounts it when idle (you cannot run binaries from it)
 
-Run:
+At boot, the loader waits for the internal disk, copies the payload into `/mnt/Memory`, and starts `smbd` from RAM; tiny mDNS/NBNS helper binaries advertise the share over Bonjour.
 
-```bash
-.venv/bin/tcapsule configure
-```
+- **Auth**: any username with the Time Capsule's device password. At boot the device reads its live AirPort `syPW` value, generates the Samba password file in RAM (so password changes are picked up after reboot), and starts with guest access disabled.
+- **Boot persistence**: NetBSD 6 devices auto-start on boot. NetBSD 4 devices need `activate` after every reboot, or `flash --patch` to install a persistent boot hook.
+- **Uninstall** removes the managed files; Apple wipes everything except `/mnt/Flash` after reboot, so deleting the 7 loader files plus the `.samba4` folder restores a factory-clean device.
 
-This writes a hidden `.env` file in the repo folder, and the other `tcapsule` commands use that file as their local device configuration.
+## Security
 
-At the start of `configure`, the tool first tries to discover your Time Capsule on the local network via mDNS/Bonjour. If it finds one, it prefills the SSH target for you. If it does not find one, it falls back to the normal manual prompt flow.
-
-`configure` also checks whether SSH is reachable. If SSH is closed, it enables SSH using the built-in Python 3 ACP client, reboots the device, waits for SSH to come up, and then continues the normal probing flow. If the password is wrong, it asks again instead of writing a broken `.env` file.
-
-The password you enter here is stored locally as `TC_PASSWORD` so the tool can keep using SSH and ACP. The managed Samba runtime reads the current device password on the Time Capsule at boot. In other words, after setup, you normally connect with:
-
-- username: `admin` (or any other password)
-- password: the same Time Capsule password you entered during configuration
-
-Samba does not use Apple’s internal password backend directly. The boot script reads the AirPort `syPW` setting, asks `mdns-advertiser` to generate the NT hash, and writes the RAM-only Samba auth files before `smbd` starts.
-
-## Step 3: Deploy It
-
-Run:
-
-```bash
-.venv/bin/tcapsule deploy
-```
-
-This step installs (or updates) Samba onto the device. It validates the checked-in binaries and copies the payload and boot files to the Time Capsule. Samba password files are generated on the device in RAM each time the managed runtime stages. You can run `deploy` for a new version to update.
-
-On Gen 5 NetBSD 6 devices, `deploy` reboots the device so the new runtime comes up cleanly.
-On older Gen 1-4 NetBSD 4 devices, `deploy` also reboots to clear the RAM disk, waits for SSH to return, and then runs `/mnt/Flash/rc.local`. The older devices still need `tcapsule activate` after later reboots that are not part of `deploy`.
-
-By default, `tcapsule deploy` reboots after deployment and then waits for the device to come back. If you want to skip the reboot confirmation prompt, you can run:
-
-```bash
-.venv/bin/tcapsule deploy --yes
-```
-
-There are also other flags such as `--no-nbns`, `--no-reboot` and `--dry-run`, but leave those alone unless you have a specific reason to use them. `--no-reboot` uploads the files, stops the manager process and `wcifsfs`, and starts the deployed runtime immediately by running `/mnt/Flash/rc.local`.
-
-If you want a machine-readable deployment plan without changing the device, use:
-
-```bash
-.venv/bin/tcapsule deploy --dry-run --json
-```
-
-## Step 4: Flash, or Activate It Again If Needed
-
-This is for older Gen 1-4 devices. Run:
-
-```bash
-.venv/bin/tcapsule flash
-```
-
-To back up the flash on your device. Then run: 
-
-```bash
-.venv/bin/tcapsule flash --patch
-```
-This will then patch a small boot hook launcher (to the primary firmware bank only). It just tells the device to run the `/mnt/Flash/rc.local` file at every startup.
-
-On supported devices, `tcapsule flash --patch` can install the persistent boot hook and `tcapsule flash --restore` can restore a selected target bank from Apple stock firmware downloaded from Apple's catalog. Both write modes modify only one bank and leave the other flash bank untouched, then run validation by reading the written bank back after ACP accepts the write. Patch mode targets the primary bank. Restore mode uses the selected active bank when only one bank passes active selection; if both banks pass and primary is safe, restore targets primary.
-
-Patch mode cannot send a reboot or poweroff command after a successful write. After `tcapsule flash --patch` reports success, a user needs to manually
-unplug the device to reboot, and then wait a few minutes for the device to boot to run `tcapsule doctor`. Restore mode can request a software reboot with `tcapsule flash --restore --reboot`; after that, use `tcapsule flash --check-apple` to verify the candidate bank or banks match Apple stock firmware.
-
-If you do not want to patch the device, run:
-
-```bash
-.venv/bin/tcapsule activate
-```
-
-It starts Samba without copying the files again.  
-For older Gen 1-4 hardware, this is currently needed after reboot because by default the firmware does not persist the boot hook needed to auto-start Samba. 
-
-Unfortunately, you need to run `activate` after *every* reboot for older devices that do not start Samba automatically, if you do not run `flash`.
-
-## Step 5: Verify The Result
-
-Run:
-
-```bash
-.venv/bin/tcapsule doctor
-```
-
-This is a non-destructive diagnostic command. `tcapsule doctor` checks:
-
-- that the required local tools exist
-- that your `.env` exists, is complete, and is valid
-- that the checked-in binaries are present and match the expected checksums
-- that SSH is reachable
-- that the configured remote network interface, detected device compatibility, and selected payload family look sane
-- that the managed runtime is up:
-  - `smbd` is running and bound to TCP 445
-  - the managed mDNS takeover is active
-  - the NBNS responder is checked unless disabled
-- what the box is currently advertising and serving for:
-  - Bonjour instance name
-  - Bonjour host label
-  - Samba NetBIOS name
-  - Samba share names
-- that SMB is reachable
-- that Bonjour `_smb._tcp` advertisement is visible and resolves
-- that an authenticated SMB listing actually works and includes the active share name
-- that authenticated SMB file operations also work on the share
-- that `xattr_tdb:file` in the active Samba config points at persistent storage instead of the RAM disk
-
-If you want the results in JSON instead of human-readable text, use:
-
-```bash
-.venv/bin/tcapsule doctor --json
-```
-
-## Step 6: Remove It Later If Needed
-
-Run:
-
-```bash
-.venv/bin/tcapsule uninstall
-```
-
-This removes the managed TimeCapsuleSMB payload from the internal disk and removes the loader files from `/mnt/Flash`. Apple wipes the filesystem on the device after every reboot, except for `/mnt/Flash`, so that's where we install the loader scripts. If you delete the 7 payload files in `/mnt/Flash`, delete the `.samba4` folder on the hard drive, and then reboot, you can restore your machine to factory clean condition.
-
-By default `uninstall` asks before rebooting the Time Capsule. If you want to skip the reboot confirmation prompt, use:
-
-```bash
-.venv/bin/tcapsule uninstall --yes
-```
-
-If you want to preview the uninstall plan without changing the device, use:
-
-```bash
-.venv/bin/tcapsule uninstall --dry-run
-.venv/bin/tcapsule uninstall --dry-run --json
-```
-
-Uninstall success means the managed payload and boot files are gone after reboot. It does **not** check whether Apple SMB or AFP is enabled afterward. Those services may be on or off depending on the device's own settings. 
-
-If you want to remove the files without rebooting immediately, use:
-
-```bash
-.venv/bin/tcapsule uninstall --no-reboot
-```
-
-## Connecting From Finder
-
-Once deployment has completed and the Time Capsule has rebooted, you should be able to connect from Finder. The device should show up in the "Network" folder, or with:
-
-```text
-smb://<advertised-host>.local/<share-name>
-```
-
-When Finder prompts for credentials, use:
-
-- username: `admin` or any username
-- password: your Time Capsule password
-
-## Technical Notes
-
-The rest of this README is more technical and explains why the repo is structured this way.
-
-## Design
-
-The Time Capsule hardware is extremely old and constrained. It has three relevant storage areas:
-
-- `/mnt/Flash`, which is persistent but only has ~900KB of free space.
-- `/mnt/Memory`, which is a 16MB ramdisk
-- the internal HDD mounted under `/Volumes/dk2` or `/Volumes/dk3`, which is large but managed by Apple and unmounts when idle. You cannot run a binary off this location for that reason.
-
-Unfortunately, it was not an option to "copy one binary somewhere and call it a day" to get `smbd` running. Thus, the current process is:
-
-1. Keep the full `smbd` payload on the big internal hard disk.
-2. Keep only a very small `rc.local` boot script on flash.
-3. At boot, wait for the internal disk to appear and mount.
-4. Copy the runtime binaries into `/mnt/Memory`.
-5. Start Samba from the `/mnt/Memory`, not from the big disk Apple may later decide to unmount.
-6. Advertise `_smb._tcp` with a separate tiny mDNS helper.
-
-That is the reason the repository contains both:
-
-- [bin/samba4/smbd](bin/samba4/smbd)
-- [bin/mdns/mdns-advertiser](bin/mdns/mdns-advertiser)
-
-and boot files such as:
-
-- [src/timecapsulesmb/assets/boot/samba4/rc.local](src/timecapsulesmb/assets/boot/samba4/rc.local)
-- [src/timecapsulesmb/assets/boot/samba4/boot.sh](src/timecapsulesmb/assets/boot/samba4/boot.sh)
-- [src/timecapsulesmb/assets/boot/samba4/manager.sh](src/timecapsulesmb/assets/boot/samba4/manager.sh)
-
-There are other constraints the Time Capsule places on us:  
-- The NetBSD 6 source code does not support earmv4 builds, so we need to build from NetBSD 7.
-- Samba 3.x compiles easily, but it doesn't support directory traversal with SMB2 on NetBSD 6. This is a known bug apparently.
-- Samba 4.0.x has the same issue
-- Samba 4.2.x was much harder to compile, and had a `talloc` / `loadparm` use-after-free runtime bug
-- Samba 4.3.x was the first version to work as a network share, but it does not support vfs_fruit for Time Machine backup support
-- Samba 4.8.x was the first version that fully worked; current builds ship Samba 4.24.3.
+LAN-only setup — do not expose this SMB service to the public internet or forward ports to it. SMB access maps to `root` internally (a deliberate compatibility choice for this old firmware). Telemetry and logging are enabled by default.
 
 ## Troubleshooting
 
-Please read [FAQ.md](FAQ.md) as well. 
+- **Device not in Finder**: run `tcapsule doctor`, then `dns-sd -B _smb._tcp local.` — the service can be up and correct even when Finder browsing is slow.
+- **Finder still can't connect**: reboot, then try `smb://<advertised-host>.local/<share>` directly, or use the IP from your `.env`.
+- **Deploy says SMB listing failed right after reboot**: these old CPUs are slow — wait a little, then run `tcapsule doctor`.
+- Anything else: see [FAQ.md](FAQ.md), or file an issue.
 
-### The Time Capsule Does Not Show Up In Finder
+## For developers
 
-Run:
-
-```bash
-.venv/bin/tcapsule doctor
-```
-
-Then check Bonjour directly:
-
-```bash
-dns-sd -B _smb._tcp local.
-```
-
-To inspect discovery results from the tool itself, run:
-
-```bash
-.venv/bin/tcapsule discover --json
-```
-
-If the system is working normally, you should see an `_smb._tcp` service with the Time Capsule's current device name.
-
-Finder is not always the best first diagnostic tool. The service can be up and correct even when Finder browsing is being slow or temperamental.
-
-### Finder Still Does Not Connect
-
-Try a reboot, then try the direct address explicitly:
-
-```text
-smb://<advertised-host>.local/<share-name>
-```
-
-If necessary, use the IP address from your `.env` instead. The point is to separate “Bonjour browsing did something odd” from “SMB itself is broken.”
-
-### Deploy Says SMB Listing Failed Right After Reboot
-
-That can happen if the device has come back on the network but is still finishing startup. These old Time Capsule CPUs are not fast.
-
-Wait a little, then run:
-
-```bash
-.venv/bin/tcapsule doctor
-```
-
-### I Want The Full Technical Story
-
-Read:
-
-- [DETAIL.md](DETAIL.md)
-
-This explains the engineering constraints, historical dead ends, and current implementation in much more detail.
-
-## Security Notes
-
-This should be treated as a LAN-only setup. Do not expose this SMB service directly to the public internet! Do not forward ports to it. I have tested this with an M1 Macbook Pro and an A1470 Time Capsule. Your mileage may vary. 
-
-Also note that the current auth model maps SMB access to `root` internally on the Time Capsule. That is a deliberate compatibility choice for this old firmware, as the version of NetBSD 6 running on the Time Capsule errors when Samba tries to switch users.
-
-The commands have logging and telemetry enabled by default. Errors and exceptions are logged so they can be easily investigated later.
-
-## For Developers And Maintainers
-
-The checked-in binaries are already built. If you want to rebuild them yourself, the maintainer build flow lives under [build/](build) and depends on a NetBSD VM.
-
-The main build outputs are:
-
-- [bin/samba4/smbd](bin/samba4/smbd)
-- [bin/samba4-netbsd4le/smbd](bin/samba4-netbsd4le/smbd)
-- [bin/samba4-netbsd4be/smbd](bin/samba4-netbsd4be/smbd)
-- [bin/mdns/mdns-advertiser](bin/mdns/mdns-advertiser)
-- [bin/mdns-netbsd4le/mdns-advertiser](bin/mdns-netbsd4le/mdns-advertiser)
-- [bin/mdns-netbsd4be/mdns-advertiser](bin/mdns-netbsd4be/mdns-advertiser)
-- [bin/nbns/nbns-advertiser](bin/nbns/nbns-advertiser)
-- [bin/nbns-netbsd4le/nbns-advertiser](bin/nbns-netbsd4le/nbns-advertiser)
-- [bin/nbns-netbsd4be/nbns-advertiser](bin/nbns-netbsd4be/nbns-advertiser)
+- Full technical story, engineering constraints, and historical dead ends: [DETAIL.md](DETAIL.md)
+- Contributing, testing, and device constraints: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Rebuilding the NetBSD binaries: `build/` (requires a NetBSD VM; the checked-in `bin/` files are ready to use)
+- Release process: [RELEASE.md](RELEASE.md)


### PR DESCRIPTION
## Summary
Local repo-tooling polish (committed as one change set):

- **Makefile**: `make install` now always installs the `.[dev]` extras (previously only on first venv creation — an existing `.venv` from `./tcapsule bootstrap` made it a silent no-op and `make lint` failed with `No module named ruff`). Help usage line now lists `dry=1`/`no-reboot=1`/`reboot=1`.
- **README.md**: the Makefile-stages sentence now matches the real target set (`fsck`/`repair-xattrs`, `flash-*` variants, all vars).
- **AGENTS.md** (new): repo-specific agent guidance — bootstrap/dev-extras gotcha, workflow stages, device constraints, test-file map, XCTest/CommandLineTools quirk, active-rewrite oracle note.
- **AGENTS-REWRITE.md** (new): the filled clean-architecture rewrite meta-prompt (workflow for the rewrite into apple-time-capsule-utils).
- **.gitignore**: ignore `*.log`/device logs (matches the AGENTS.md 'never commit device logs' rule).

No functional code changes; all Makefile targets verified (`make install`/`lint`/`help`).