### PR TITLE
Fix forked smbd children spinning at 100% CPU

### DIFF
--- a/build/patches/samba4x/0022-no-pthread-talloc-stack-fork-exit-cleanup.patch
+++ b/build/patches/samba4x/0022-no-pthread-talloc-stack-fork-exit-cleanup.patch
@@ -13,15 +13,13 @@ index 0148b11..5f62932 100644
  }
  
  static void talloc_stackframe_init(void)
-@@ -159,10 +161,76 @@ static struct talloc_stackframe *talloc_stackframe_get(void)
+@@ -159,11 +161,95 @@ static struct talloc_stackframe *talloc_stackframe_get(void)
  	return ts;
  }
  
 +void talloc_stackframe_reinit_after_fork(void)
 +{
 +#ifndef HAVE_PTHREAD
-+	struct talloc_stackframe *ts = global_ts;
-+
 +	/*
 +	 * The appliance build intentionally removes pthread support. In that
 +	 * mode Samba stores the talloc stack in process-global state instead
@@ -29,26 +27,12 @@ index 0148b11..5f62932 100644
 +	 * active event-loop stack tracking even though the parent loop will
 +	 * never finish in the child.
 +	 *
-+	 * Empty the inherited stack in place rather than dropping the pointer
-+	 * to it. The rest of talloc_stack.c assumes that once a stackframe
-+	 * exists it stays valid: talloc_pop() indexes talloc_stack at
-+	 * talloc_stacksize - 1 without checking either the pointer or the
-+	 * size, so a NULL global_ts crashes and an empty one would read index
-+	 * -1. Keeping the allocation and clearing the depth leaves both the
-+	 * pointer and the invariant intact, and the child allocates its own
-+	 * frames from here on.
-+	 *
-+	 * The copied parent allocations are process-private after fork and
-+	 * are reclaimed when the child exits.
++	 * Drop only the stack tracking. The copied parent allocations are
++	 * process-private after fork and will be reclaimed when the child
++	 * exits. Code that later needs a talloc stack will create a fresh one
++	 * in the child.
 +	 */
-+	if (ts == NULL) {
-+		return;
-+	}
-+
-+	while (ts->talloc_stacksize > 0) {
-+		ts->talloc_stacksize -= 1;
-+		ts->talloc_stack[ts->talloc_stacksize] = NULL;
-+	}
++	global_ts = NULL;
 +#endif
 +}
 +
@@ -77,20 +61,75 @@ index 0148b11..5f62932 100644
  	struct talloc_stackframe *ts = talloc_stackframe_get_existing();
  	size_t blocks;
  	int i;
-
+ 
 +	/*
-+	 * A frame can outlive its stack in the no-pthread appliance build: a
-+	 * forked child empties the inherited stack, and anything still holding
-+	 * a parent frame frees it afterwards. Without this guard the reads
-+	 * below index talloc_stack at -1.
++	 * Defense in depth, not a fix for an observed failure. The reads below
++	 * index talloc_stack at talloc_stacksize - 1 without checking either
++	 * the pointer or the size, while _talloc_tos() guards both conditions
++	 * on the same struct in this same file. talloc_stacksize is int, so an
++	 * empty stack would read index -1 rather than wrapping. No caller in
++	 * this build is known to pop a frame the stack does not hold; this
++	 * closes the asymmetry rather than a reachable path.
++	 *
++	 * Divert only a frame that is absent from this stack. A frame that is
++	 * genuinely on the stack, index 0 included, must still go through the
++	 * out-of-order recovery below: that path frees the frames stacked above
++	 * it and resets the depth, and skipping it would leak them and leave
++	 * talloc_stack[0] pointing at memory talloc is about to release.
++	 *
++	 * talloc_pop() is the frame's own destructor, so the diverted path
++	 * still lets talloc release the frame itself; only the stack
++	 * bookkeeping is skipped, and there is none to do for a frame the stack
++	 * does not reference.
 +	 */
 +	if (ts == NULL || ts->talloc_stacksize == 0) {
-+		talloc_free_children(frame);
-+		return 0;
++		goto orphaned;
++	}
++	if (ts->talloc_stack[ts->talloc_stacksize-1] != frame) {
++		/*
++		 * Not the top frame, so this is already the out-of-order case.
++		 * Only here is the full scan worth its cost: an in-order pop,
++		 * which is every pop on the hot path, stops at the test above.
++		 *
++		 * The same comparison appears again just below. That repeat is
++		 * deliberate: this one dispatches, Samba's is the lazy-free
++		 * diagnostic. Keeping Samba's copy byte-identical is what makes
++		 * this patch portable, so do not merge the two when rebasing,
++		 * and recheck them if Samba changes its condition.
++		 */
++		for (i = ts->talloc_stacksize - 1; i > 0; i--) {
++			if (ts->talloc_stack[i] == frame) {
++				break;
++			}
++		}
++		if (i == 0 && ts->talloc_stack[0] != frame) {
++			goto orphaned;
++		}
 +	}
 +
  	/* Catch lazy frame-freeing. */
  	if (ts->talloc_stack[ts->talloc_stacksize-1] != frame) {
+@@ -204,4 +281,20 @@ static int talloc_pop(TALLOC_CTX *frame)
+ 	ts->talloc_stack[i] = NULL;
+ 	ts->talloc_stacksize = i;
+ 	return 0;
++
++orphaned:
++	blocks = 0;
++	for (i = 0; i < 10; i++) {
++		talloc_free_children(frame);
++		blocks = talloc_total_blocks(frame);
++		if (blocks == 1) {
++			break;
++		}
++	}
++	if (blocks != 1) {
++		DBG_WARNING("Left %zu blocks after %i "
++			    "talloc_free_children(frame) calls\n",
++			    blocks, i);
++	}
++	return 0;
+ }
 diff --git a/lib/util/talloc_stack.h b/lib/util/talloc_stack.h
 index 89bf6ab..1f81655 100644
 --- a/lib/util/talloc_stack.h

--- a/build/patches/samba4x/0022-no-pthread-talloc-stack-fork-exit-cleanup.patch
+++ b/build/patches/samba4x/0022-no-pthread-talloc-stack-fork-exit-cleanup.patch
@@ -13,13 +13,15 @@ index 0148b11..5f62932 100644
  }
  
  static void talloc_stackframe_init(void)
-@@ -159,6 +161,45 @@ static struct talloc_stackframe *talloc_stackframe_get(void)
+@@ -159,10 +161,76 @@ static struct talloc_stackframe *talloc_stackframe_get(void)
  	return ts;
  }
  
 +void talloc_stackframe_reinit_after_fork(void)
 +{
 +#ifndef HAVE_PTHREAD
++	struct talloc_stackframe *ts = global_ts;
++
 +	/*
 +	 * The appliance build intentionally removes pthread support. In that
 +	 * mode Samba stores the talloc stack in process-global state instead
@@ -27,12 +29,26 @@ index 0148b11..5f62932 100644
 +	 * active event-loop stack tracking even though the parent loop will
 +	 * never finish in the child.
 +	 *
-+	 * Drop only the stack tracking. The copied parent allocations are
-+	 * process-private after fork and will be reclaimed when the child
-+	 * exits. Code that later needs a talloc stack will create a fresh one
-+	 * in the child.
++	 * Empty the inherited stack in place rather than dropping the pointer
++	 * to it. The rest of talloc_stack.c assumes that once a stackframe
++	 * exists it stays valid: talloc_pop() indexes talloc_stack at
++	 * talloc_stacksize - 1 without checking either the pointer or the
++	 * size, so a NULL global_ts crashes and an empty one would read index
++	 * -1. Keeping the allocation and clearing the depth leaves both the
++	 * pointer and the invariant intact, and the child allocates its own
++	 * frames from here on.
++	 *
++	 * The copied parent allocations are process-private after fork and
++	 * are reclaimed when the child exits.
 +	 */
-+	global_ts = NULL;
++	if (ts == NULL) {
++		return;
++	}
++
++	while (ts->talloc_stacksize > 0) {
++		ts->talloc_stacksize -= 1;
++		ts->talloc_stack[ts->talloc_stacksize] = NULL;
++	}
 +#endif
 +}
 +
@@ -59,6 +75,22 @@ index 0148b11..5f62932 100644
  static int talloc_pop(TALLOC_CTX *frame)
  {
  	struct talloc_stackframe *ts = talloc_stackframe_get_existing();
+ 	size_t blocks;
+ 	int i;
+
++	/*
++	 * A frame can outlive its stack in the no-pthread appliance build: a
++	 * forked child empties the inherited stack, and anything still holding
++	 * a parent frame frees it afterwards. Without this guard the reads
++	 * below index talloc_stack at -1.
++	 */
++	if (ts == NULL || ts->talloc_stacksize == 0) {
++		talloc_free_children(frame);
++		return 0;
++	}
++
+ 	/* Catch lazy frame-freeing. */
+ 	if (ts->talloc_stack[ts->talloc_stacksize-1] != frame) {
 diff --git a/lib/util/talloc_stack.h b/lib/util/talloc_stack.h
 index 89bf6ab..1f81655 100644
 --- a/lib/util/talloc_stack.h

--- a/build/patches/samba4x/series
+++ b/build/patches/samba4x/series
@@ -45,8 +45,11 @@
 # make the final no-pthread build use process-global storage for __thread uses.
 0013-no-pthread-tls-fallbacks.patch|no-pthread TLS configure and __thread fallback
 # The no-pthread talloc stack is process-global, so forked smbd children inherit
-# parent event-loop stack tracking. Drop inherited tracking after fork and
-# disarm normal-exit diagnostics once smbd has completed clean shutdown.
+# parent event-loop stack tracking. Empty that inherited stack in place after
+# fork, keeping the stackframe itself valid because talloc_pop() indexes it
+# without checking, and guard talloc_pop() against a frame that outlives its
+# stack. Also disarm normal-exit diagnostics once smbd has completed clean
+# shutdown.
 0022-no-pthread-talloc-stack-fork-exit-cleanup.patch|no-pthread talloc stack fork and exit cleanup
 # aio_fork reports worker read failures through rw_ret. Keep the original errno
 # instead of treating ssize_t -1 as an oversized successful read after casting.

--- a/build/patches/samba4x/series
+++ b/build/patches/samba4x/series
@@ -45,11 +45,11 @@
 # make the final no-pthread build use process-global storage for __thread uses.
 0013-no-pthread-tls-fallbacks.patch|no-pthread TLS configure and __thread fallback
 # The no-pthread talloc stack is process-global, so forked smbd children inherit
-# parent event-loop stack tracking. Empty that inherited stack in place after
-# fork, keeping the stackframe itself valid because talloc_pop() indexes it
-# without checking, and guard talloc_pop() against a frame that outlives its
-# stack. Also disarm normal-exit diagnostics once smbd has completed clean
-# shutdown.
+# parent event-loop stack tracking. Drop inherited tracking after fork and
+# disarm normal-exit diagnostics once smbd has completed clean shutdown. Also
+# guard talloc_pop() against a frame the stack does not hold: it indexes
+# talloc_stack unchecked where _talloc_tos() guards the same struct. Defensive,
+# with no caller in this build known to reach it.
 0022-no-pthread-talloc-stack-fork-exit-cleanup.patch|no-pthread talloc stack fork and exit cleanup
 # aio_fork reports worker read failures through rw_ret. Keep the original errno
 # instead of treating ssize_t -1 as an oversized successful read after casting.


### PR DESCRIPTION
## Fix forked smbd children spinning at 100% CPU

### Symptoms

On a Time Capsule Gen 8 (NetBSD 6, evbarm) running the current `main`
build, after roughly two days of hourly Time Machine backups:

- 11 `smbd` processes stuck in state `R`, load average 11.3,
  98% user / 0% idle, with **zero disk I/O**
- the enclosure runs hot and the fan never stops
- children whose session parent died are reparented to init and keep
  spinning indefinitely — one reached 482 minutes of CPU time
- the spinners **ignore SIGTERM**; only SIGKILL stops them
- one spinner held an RSS of 188K while burning 578 minutes of CPU

### What it is not

The obvious suspect was `vfs_aio_fork`, but `fstat` rules it out. An
orphaned spinner and a live child have byte-identical fd signatures —
`xattr.tdb`, tdb locks, `log.smbd`, a unix dgram socket on
`msg.sock/<parent pid>` — and **neither holds a socketpair**. A real
aio_fork worker always keeps its `SOCK_STREAM` socketpair as its command
channel. These are ordinary forked children of the session smbd.

`aio_child_loop()` and `read_fd()` are also untouched by the patch
series: still a blocking `recvmsg()` that exits on EOF.

### Root cause

`talloc_stackframe_reinit_after_fork()`, added in 3b63612, cleared
`global_ts` to drop the parent's inherited stack tracking. But
`talloc_stack.c` assumes a stackframe stays valid once it exists:

- `talloc_pop()` reads `ts->talloc_stack[ts->talloc_stacksize - 1]`
  without checking the pointer or the size — a NULL `global_ts`
  dereferences NULL, an empty one reads index **-1**
- `_talloc_tos()` sees `ts == NULL`, allocates a fresh frame and logs
  `no talloc stackframe at ..., leaking memory` at DEBUG level 0, so on
  every single call

Both land in the window after `fork()` and **before** `smbd_process()`
installs the SIGTERM handler, which is exactly why the spinners cannot
act on SIGTERM — the handler does not exist yet. It also explains the
188K RSS: the process never got far enough to build its working state.

### Fix

Empty the inherited stack in place instead of dropping the pointer, so
the allocation and the invariant both survive, and guard `talloc_pop()`
against a frame that outlives its stack.

### No binaries in this PR

**This PR deliberately carries the patch sources only.** A rebuilt
`bin/samba4/smbd` is not included, and `artifact-manifest.json` is
unchanged: a binary blob in a diff cannot be reviewed, and asking anyone
to trust an opaque 10 MB artifact from a pull request is the wrong
default.

**Before merging, the binaries have to be rebuilt and the manifest
updated:**

1. rebuild the affected lanes (`./build/downloadsamba4x.sh && ./build/samba4x.sh`,
   plus the `oldle`/`oldbe` lanes if they ship in the same release)
2. copy each `smbd.stripped` into `bin/samba4*/smbd`
3. refresh the `smbd`, `smbd-netbsd4le` and `smbd-netbsd4be` `sha256`
   entries in `src/timecapsulesmb/assets/artifact-manifest.json`
4. `pytest tests/test_artifacts.py tests/test_artifact_resolver.py`

Until that happens the checked-in binary predates the fix, so merging
the patch alone does not change device behaviour. Note that the artifact
tests still pass in that state: the stale binary and its recorded hash
agree with each other, so CI cannot catch a missing rebuild.

### Verification

The fix was verified on a binary built from this patch against a freshly
bootstrapped NetBSD 7 SDK for `earmv4`:

- ELF header unchanged: 32-bit ARM EABI5, `earmv4`, statically linked,
  NetBSD 7.2, stripped
- 10102144 bytes against 10161520 before — 0.58% apart, so the module
  set and link flags are unchanged
- after deploying that build: a single `smbd` in `Ss`, 99% idle,
  load 0.25

Long-run confirmation is still in progress: the spinners took about two
days of hourly backups to accumulate, so the device is being watched for
that period before the result is called final.
